### PR TITLE
#25 feat ユーザのハンドルネーム、かな、ハンドルネームのかなを登録できるようにする

### DIFF
--- a/front/apollo/graphql.ts
+++ b/front/apollo/graphql.ts
@@ -65,6 +65,9 @@ export type User = {
   __typename?: 'User';
   id: Scalars['ID'];
   name: Scalars['String'];
+  name_kana: Scalars['String'];
+  handle_name: Scalars['String'];
+  handle_name_kana: Scalars['String'];
   email: Scalars['String'];
   created_at: Scalars['DateTime'];
   updated_at: Scalars['DateTime'];
@@ -83,6 +86,9 @@ export type MutationCreateUserArgs = {
 
 export type UserInput = {
   name: Scalars['String'];
+  name_kana: Scalars['String'];
+  handle_name: Scalars['String'];
+  handle_name_kana: Scalars['String'];
   email: Scalars['String'];
   password: Scalars['String'];
 };

--- a/front/components/users/UserForm.vue
+++ b/front/components/users/UserForm.vue
@@ -9,10 +9,18 @@
           <v-text-field v-model="syncedUser.name_kana" outlined label="かな" />
         </v-col>
         <v-col cols="12">
-          <v-text-field v-model="syncedUser.handle_name" outlined label="ハンドルネーム" />
+          <v-text-field
+            v-model="syncedUser.handle_name"
+            outlined
+            label="ハンドルネーム"
+          />
         </v-col>
         <v-col cols="12">
-          <v-text-field v-model="syncedUser.handle_name_kana" outlined label="ハンドルネームのかな" />
+          <v-text-field
+            v-model="syncedUser.handle_name_kana"
+            outlined
+            label="ハンドルネームのかな"
+          />
         </v-col>
         <v-col cols="12">
           <v-text-field

--- a/front/components/users/UserForm.vue
+++ b/front/components/users/UserForm.vue
@@ -6,7 +6,13 @@
           <v-text-field v-model="syncedUser.name" label="名前" outlined />
         </v-col>
         <v-col cols="12">
-          <v-text-field outlined label="ニックネーム" />
+          <v-text-field v-model="syncedUser.name_kana" outlined label="かな" />
+        </v-col>
+        <v-col cols="12">
+          <v-text-field v-model="syncedUser.handle_name" outlined label="ハンドルネーム" />
+        </v-col>
+        <v-col cols="12">
+          <v-text-field v-model="syncedUser.handle_name_kana" outlined label="ハンドルネームのかな" />
         </v-col>
         <v-col cols="12">
           <v-text-field

--- a/front/pages/users/create.vue
+++ b/front/pages/users/create.vue
@@ -19,6 +19,9 @@ import UserForm from '~/components/users/UserForm.vue'
 export default class CreateUser extends Vue {
   user: UserInput = {
     name: '',
+    name_kana: '',
+    handle_name: '',
+    handle_name_kana: '',
     email: '',
     password: '',
   }

--- a/laravel/app/Models/User.php
+++ b/laravel/app/Models/User.php
@@ -18,6 +18,9 @@ class User extends Authenticatable
      */
     protected $fillable = [
         'name',
+        'name_kana',
+        'handle_name',
+        'handle_name_kana',
         'email',
         'password',
     ];

--- a/laravel/database/migrations/2020_11_08_144557_add_kana_columns_users_table_migration.php
+++ b/laravel/database/migrations/2020_11_08_144557_add_kana_columns_users_table_migration.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddKanaColumnsUsersTableMigration extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        //
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('name_kana', 255)->after('name');
+            $table->string('handle_name', 255)->after('name_kana');
+            $table->string('handle_name_kana', 255)->after('handle_name');
+    });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        //
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('name_kana');
+            $table->dropColumn('handle_name');
+            $table->dropColumn('handle_name_kana');
+        });
+    }
+}

--- a/laravel/graphql/schema.graphql
+++ b/laravel/graphql/schema.graphql
@@ -13,6 +13,9 @@ type Query {
 type User {
     id: ID!
     name: String!
+    name_kana: String!
+    handle_name: String!
+    handle_name_kana: String!
     email: String!
     created_at: DateTime!
     updated_at: DateTime!
@@ -25,6 +28,9 @@ type Mutation {
 
 input UserInput {
     name: String!
+    name_kana: String!
+    handle_name: String!
+    handle_name_kana: String!
     email: String!
     password: String!
 }

--- a/laravel/tests/Graphql/UserTest.php
+++ b/laravel/tests/Graphql/UserTest.php
@@ -18,6 +18,9 @@ class UserTest extends TestCase
     {
         $userInput = [
             'name' => $this->faker->name,
+            'name_kana' => $this->faker->name,
+            'handle_name' => $this->faker->name,
+            'handle_name_kana' => $this->faker->name,
             'email' => $this->faker->safeEmail,
             'password' => $this->faker->password,
         ];
@@ -27,6 +30,9 @@ class UserTest extends TestCase
                 createUser(input: $input) {
                     id
                     name
+                    name_kana
+                    handle_name
+                    handle_name_kana
                     email
                 }
             }

--- a/mock/src/generated/graphql.ts
+++ b/mock/src/generated/graphql.ts
@@ -64,6 +64,9 @@ export type User = {
   __typename?: 'User';
   id: Scalars['ID'];
   name: Scalars['String'];
+  name_kana: Scalars['String'];
+  handle_name: Scalars['String'];
+  handle_name_kana: Scalars['String'];
   email: Scalars['String'];
   created_at: Scalars['DateTime'];
   updated_at: Scalars['DateTime'];
@@ -82,6 +85,9 @@ export type MutationCreateUserArgs = {
 
 export type UserInput = {
   name: Scalars['String'];
+  name_kana: Scalars['String'];
+  handle_name: Scalars['String'];
+  handle_name_kana: Scalars['String'];
   email: Scalars['String'];
   password: Scalars['String'];
 };

--- a/mock/src/generated/schema.json
+++ b/mock/src/generated/schema.json
@@ -325,6 +325,54 @@
             "deprecationReason": null
           },
           {
+            "name": "name_kana",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "handle_name",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "handle_name_kana",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "email",
             "description": null,
             "args": [],
@@ -448,6 +496,48 @@
         "inputFields": [
           {
             "name": "name",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "name_kana",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "handle_name",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "handle_name_kana",
             "description": null,
             "type": {
               "kind": "NON_NULL",


### PR DESCRIPTION
resolve: #25 

## この PR で実装される内容
ユーザのハンドルネーム、かな、ハンドルネームのかなを登録できるようにする

## 悩ましい（見てほしい）部分

## 確認

-   [x] test 画面から入力した内容が登録される
![image](https://user-images.githubusercontent.com/72699098/98468986-524ce100-2220-11eb-9e40-a7873cceb9c4.png)
![image](https://user-images.githubusercontent.com/72699098/98468991-5d077600-2220-11eb-8148-806828e3d26f.png)

## 備考
