### PR TITLE
#38 ID値はorderdUuidを使うようにする

### DIFF
--- a/laravel/app/Console/Commands/Make/MakeModelCommand.php
+++ b/laravel/app/Console/Commands/Make/MakeModelCommand.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Console\Commands\Make;
+
+use Illuminate\Foundation\Console\ModelMakeCommand;
+
+class MakeModelCommand extends ModelMakeCommand
+{
+    /**
+     * Get the stub file for the generator.
+     *
+     * @return string
+     */
+    protected function getStub()
+    {
+        return __DIR__ . '/stubs/model.stub';
+    }
+}

--- a/laravel/app/Console/Commands/Make/stubs/model.stub
+++ b/laravel/app/Console/Commands/Make/stubs/model.stub
@@ -1,0 +1,10 @@
+<?php
+
+namespace {{ namespace }};
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+
+class {{ class }} extends Model
+{
+    use HasFactory;
+}

--- a/laravel/app/Console/Kernel.php
+++ b/laravel/app/Console/Kernel.php
@@ -13,7 +13,7 @@ class Kernel extends ConsoleKernel
      * @var array
      */
     protected $commands = [
-        //
+        \App\Console\Commands\Make\MakeModelCommand::class
     ];
 
     /**
@@ -34,7 +34,7 @@ class Kernel extends ConsoleKernel
      */
     protected function commands()
     {
-        $this->load(__DIR__.'/Commands');
+        $this->load(__DIR__ . '/Commands');
 
         require base_path('routes/console.php');
     }

--- a/laravel/app/Models/Model.php
+++ b/laravel/app/Models/Model.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model as BaseModel;
+
+use App\Models\Traits\PrimaryKeyUuidUsable;
+
+class Model extends BaseModel
+{
+    use PrimaryKeyUuidUsable;
+
+    // primary key でuuidを使うためにoverrideする
+    public $incrementing = false;
+    protected $keyType = 'string';
+}

--- a/laravel/app/Models/Team.php
+++ b/laravel/app/Models/Team.php
@@ -3,7 +3,6 @@
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
-use Illuminate\Database\Eloquent\Model;
 
 class Team extends Model
 {

--- a/laravel/app/Models/Traits/PrimaryKeyUuidUsable.php
+++ b/laravel/app/Models/Traits/PrimaryKeyUuidUsable.php
@@ -4,6 +4,14 @@ namespace App\Models\Traits;
 
 use Illuminate\Support\Str;
 
+/**
+ * モデルを登録する際のid値の生成をuuidに変更する
+ * このTraitを使う際には以下のプロパティをオーバーライドする必要があるので、注意すること
+ * （trait内で、プロパティは定義しないほうがいいので、各クラスで行うこと）
+ *
+ * public $incrementing = false;
+ * protected $keyType = 'string';
+ */
 trait PrimaryKeyUuidUsable
 {
     protected static function bootPrimaryKeyUuidUsable()

--- a/laravel/app/Models/Traits/PrimaryKeyUuidUsable.php
+++ b/laravel/app/Models/Traits/PrimaryKeyUuidUsable.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Models\Traits;
+
+use Illuminate\Support\Str;
+
+trait PrimaryKeyUuidUsable
+{
+    protected static function bootPrimaryKeyUuidUsable()
+    {
+        static::creating(function ($model) {
+            $model->{$model->getKeyName()} = (string)Str::orderedUuid();
+        });
+    }
+}

--- a/laravel/app/Models/User.php
+++ b/laravel/app/Models/User.php
@@ -7,9 +7,15 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 
+use App\Models\Traits\PrimaryKeyUuidUsable;
+
 class User extends Authenticatable
 {
-    use HasFactory, Notifiable;
+    use HasFactory, Notifiable, PrimaryKeyUuidUsable;
+
+    // primary key でuuidを使うためにoverrideする
+    public $incrementing = false;
+    protected $keyType = 'string';
 
     /**
      * The attributes that are mass assignable.

--- a/laravel/database/migrations/2014_10_12_000000_create_users_table.php
+++ b/laravel/database/migrations/2014_10_12_000000_create_users_table.php
@@ -14,7 +14,8 @@ class CreateUsersTable extends Migration
     public function up()
     {
         Schema::create('users', function (Blueprint $table) {
-            $table->id();
+            $table->uuid('id');
+            $table->primary('id');
             $table->string('name');
             $table->string('email')->unique();
             $table->timestamp('email_verified_at')->nullable();

--- a/laravel/database/migrations/2020_11_08_173233_create_teams_table.php
+++ b/laravel/database/migrations/2020_11_08_173233_create_teams_table.php
@@ -14,7 +14,8 @@ class CreateTeamsTable extends Migration
     public function up()
     {
         Schema::create('teams', function (Blueprint $table) {
-            $table->id();
+            $table->uuid('id');
+            $table->primary('id');
             $table->string('name');
             $table->string('code')->unique();
             $table->timestamps();

--- a/laravel/tests/Graphql/TeamTest.php
+++ b/laravel/tests/Graphql/TeamTest.php
@@ -41,7 +41,7 @@ class TeamTest extends TestCase
                 ]
             ]);
         $responseData = $response->json()['data']['createTeam'];
-        $this->assertTrue(is_numeric($responseData['id']));
+        $this->assertIsUuid($responseData['id']);
         $this->assertTrue(preg_match('/^[0-9a-f]{13}$/', $responseData['code']) === 1);
         $this->assertDatabaseHas('teams', $responseData);
     }

--- a/laravel/tests/Graphql/TestCase.php
+++ b/laravel/tests/Graphql/TestCase.php
@@ -8,4 +8,10 @@ use Tests\TestCase as BaseTestCase;
 abstract class TestCase extends BaseTestCase
 {
     use MakesGraphQLRequests;
+
+    protected function assertIsUuid($value): void
+    {
+        $isUuid = preg_match('/[\d\-a-f]{36}/', $value) === 1;
+        $this->assertTrue($isUuid);
+    }
 }

--- a/laravel/tests/Graphql/UserTest.php
+++ b/laravel/tests/Graphql/UserTest.php
@@ -50,7 +50,7 @@ class UserTest extends TestCase
                 ]
             ]);
         $responseData = $response->json()['data']['createUser'];
-        $this->assertTrue(is_numeric($responseData['id']));
+        $this->assertIsUuid($responseData['id']);
         $this->assertDatabaseHas('users', $responseData);
 
         // 認証情報の確認


### PR DESCRIPTION
resolve: #38 

## この PR で実装される内容
primary keyがuuidになり、Modelを登録する際に自動生成されるようになる

## 確認

-   [ ] find可能
![image](https://user-images.githubusercontent.com/8841932/98846728-bb3b8f80-2492-11eb-9433-18cdd78e9748.png)
![image](https://user-images.githubusercontent.com/8841932/98846764-c68ebb00-2492-11eb-982b-eece9bb3eb59.png)


## 備考
本当はよろしくないが、初期段階のためmigrationを書き換えたので取り込んだ後に `migrate:fresh` する必要あり