### PR TITLE
#66 フロントエンドの ~ エイリアスにVSCodeを対応させる

### DIFF
--- a/.vscode/workspace.code-workspace
+++ b/.vscode/workspace.code-workspace
@@ -1,0 +1,21 @@
+{
+    "folders": [
+		{
+			"name": "front",
+			"path": "..\\front"
+		},
+		{
+			"name": "laravel",
+			"path": "..\\laravel"
+		},
+		{
+			"name": "mock",
+			"path": "..\\mock"
+		},
+		{
+			"name": "clapton",
+			"path": ".."
+		}
+	],
+    "settings": {}
+}

--- a/front/pages/teams/create.vue
+++ b/front/pages/teams/create.vue
@@ -7,9 +7,8 @@
 <script lang="ts">
 import 'vue-apollo'
 import { Vue, Component } from 'nuxt-property-decorator'
-import { TeamInput, CreateTeamMutation } from '../../apollo/graphql'
+import { TeamInput, CreateTeamMutation } from '~/apollo/graphql'
 import TeamForm from '~/components/teams/TeamForm.vue'
-// TODO: ~/apollo...を使えるようにする（VSCodeで読み込めるようにする）
 
 @Component({
   components: {

--- a/front/pages/users/create.vue
+++ b/front/pages/users/create.vue
@@ -7,9 +7,8 @@
 <script lang="ts">
 import 'vue-apollo'
 import { Vue, Component } from 'nuxt-property-decorator'
-import { UserInput, CreateUserMutation } from '../../apollo/graphql'
+import { UserInput, CreateUserMutation } from '~/apollo/graphql'
 import UserForm from '~/components/users/UserForm.vue'
-// TODO: ~/apollo...を使えるようにする（VSCodeで読み込めるようにする）
 
 @Component({
   components: {


### PR DESCRIPTION
resolve: #66 

## この PR で実装される内容
VSCodeで ~ エイリアスに対応される
Veturの問題で、ワークスペースの一番上のディレクトリ内でないと正常に動かないらしい。修正を待つしかないので、とりあえず使える形に対応

## 悩ましい（見てほしい）部分

## 確認

-   [x] VSCode上でエラーがなくなり、リンク先がたどれるようになっていること
![image](https://user-images.githubusercontent.com/8841932/98930797-79f1c100-2520-11eb-9c07-46116505d725.png)


## 備考
