### PR TITLE
120 チームを作成時に、初期マスタが自動登録されるようにする

### DIFF
--- a/laravel/app/Observers/TeamObserver.php
+++ b/laravel/app/Observers/TeamObserver.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace App\Observers;
+
+use App\Models\Team;
+use App\UseCase\CirclePlacementClassification\CreateCirclePlacementClassification;
+use App\UseCase\CirclePlacementClassification\CreateCirclePlacementClassificationInput;
+use App\UseCase\CircleProductClassification\CreateCircleProductClassification;
+use App\UseCase\CircleProductClassification\CreateCircleProductClassificationInput;
+use App\UseCase\WantPriority\CreateWantPriority;
+use App\UseCase\WantPriority\CreateWantPriorityInput;
+
+class TeamObserver
+{
+    private const INITIAL_CIRCLE_PLACEMENT_CLASSIFICATION_VALUES = [
+        ['name' => 'シャッター', 'cost' => 0],
+        ['name' => 'シャッター脇', 'cost' => 0],
+        ['name' => '壁', 'cost' => 0],
+        ['name' => '島壁', 'cost' => 0],
+        ['name' => '中央通路', 'cost' => 0],
+        ['name' => 'お誕生日', 'cost' => 0],
+        ['name' => '島', 'cost' => 0],
+    ];
+
+    private const INITIAL_CIRCLE_PRODUCT_CLASSIFICATION_VALUES = [
+        ['name' => '新刊'],
+        ['name' => '既刊'],
+        ['name' => 'グッズセット'],
+        ['name' => 'グッズ類'],
+        ['name' => 'CD類'],
+    ];
+
+    private const INITIAL_WANT_PRIORITY_VALUES = [
+        ['name' => '最高'],
+        ['name' => '高'],
+        ['name' => '中'],
+        ['name' => '低']
+    ];
+
+    public function created(Team $team)
+    {
+        collect(self::INITIAL_CIRCLE_PLACEMENT_CLASSIFICATION_VALUES)->each(function ($value) use ($team) {
+            $value['team_id'] = $team->id;
+            $input = new CreateCirclePlacementClassificationInput($value);
+            $useCase = new CreateCirclePlacementClassification();
+            $useCase->execute($input);
+        });
+
+        collect(self::INITIAL_CIRCLE_PRODUCT_CLASSIFICATION_VALUES)->each(function ($value) use ($team) {
+            $value['team_id'] = $team->id;
+            $input = new CreateCircleProductClassificationInput($value);
+            $useCase = new CreateCircleProductClassification();
+            $useCase->execute($input);
+        });
+
+        collect(self::INITIAL_WANT_PRIORITY_VALUES)->each(function ($value) use ($team) {
+            $value['team_id'] = $team->id;
+            $input = new CreateWantPriorityInput($value);
+            $useCase = new CreateWantPriority();
+            $useCase->execute($input);
+        });
+    }
+}

--- a/laravel/app/Providers/EventServiceProvider.php
+++ b/laravel/app/Providers/EventServiceProvider.php
@@ -7,6 +7,9 @@ use Illuminate\Auth\Listeners\SendEmailVerificationNotification;
 use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvider;
 use Illuminate\Support\Facades\Event;
 
+use App\Models\Team;
+use App\Observers\TeamObserver;
+
 class EventServiceProvider extends ServiceProvider
 {
     /**
@@ -27,6 +30,6 @@ class EventServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        //
+        Team::observe(TeamObserver::class);
     }
 }

--- a/laravel/tests/Feature/Models/TeamTest.php
+++ b/laravel/tests/Feature/Models/TeamTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Tests\Feature\Models;
+
+use Illuminate\Foundation\Testing\WithFaker;
+
+use App\Models\Team;
+use Tests\TestCase;
+
+class TeamTest extends TestCase
+{
+    use WithFaker;
+
+    public function testTeamCreatedObserver()
+    {
+        $team = Team::create([
+            'name' => $this->faker->name(),
+            'code' => Team::generateCode()
+        ]);
+
+        $this->assertEquals($team->circlePlacementClassifications->count(), 7);
+        $circlePlacementClassificationNames = $team->circlePlacementClassifications->pluck('name');
+        $this->assertContains('シャッター', $circlePlacementClassificationNames);
+
+        $this->assertEquals($team->circleProductClassifications->count(), 5);
+        $circleProductClassificationNames = $team->circleProductClassifications->pluck('name');
+        $this->assertContains('新刊', $circleProductClassificationNames);
+
+        $this->assertEquals($team->wantPriorities->count(), 4);
+        $wantPriorityNames = $team->wantPriorities->pluck('name');
+        $this->assertContains('最高', $wantPriorityNames);
+    }
+}


### PR DESCRIPTION
resolve: #120

## この PR で実装される内容
チームを作成時に配置分類、頒布物分類、優先度の初期マスタが自動登録されるようになる
