### PR TITLE
36 イベントの所属チームを持てるようにする

### DIFF
--- a/front/pages/teams/_team_id/events/create.vue
+++ b/front/pages/teams/_team_id/events/create.vue
@@ -18,6 +18,7 @@ import EventForm from '~/components/events/EventForm.vue'
 export default class CreateEvent extends Vue {
   event: EventInput = {
     name: '',
+    team_id: this.$route.params.team_id,
   }
 
   submit(): void {

--- a/laravel/app/GraphQL/Mutations/CreateEvent.php
+++ b/laravel/app/GraphQL/Mutations/CreateEvent.php
@@ -2,8 +2,11 @@
 
 namespace App\GraphQL\Mutations;
 
-use App\Models\Event;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Auth;
+
+use App\UseCase\Event\CreateEvent as CreateEventUseCase;
+use App\UseCase\Event\CreateEventInput;
 
 class CreateEvent
 {
@@ -14,8 +17,10 @@ class CreateEvent
     public function __invoke($_, array $args)
     {
         // TODO implement the resolver
-        $teamData = Arr::except($args, ['directive']);
-        $team = Event::create($teamData);
-        return $team;
+        $eventData = Arr::except($args, ['directive']);
+        $user = Auth::user();
+        $input = new CreateEventInput($eventData);
+        $event = (new CreateEventUseCase())->execute($input);
+        return $event;
     }
 }

--- a/laravel/app/Models/Event.php
+++ b/laravel/app/Models/Event.php
@@ -3,10 +3,16 @@
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 
 class Event extends Model
 {
     use HasFactory;
 
     protected $fillable = ['name'];
+
+    public function eventAffiliationTeams(): HasMany
+    {
+        return $this->hasMany(EventAffiliationTeam::class);
+    }
 }

--- a/laravel/app/Models/EventAffiliationTeam.php
+++ b/laravel/app/Models/EventAffiliationTeam.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class EventAffiliationTeam extends Model
+{
+    use HasFactory;
+
+    protected $fillable = ['event_id', 'team_id'];
+
+    public function team(): BelongsTo
+    {
+        return $this->belongsTo(Team::class);
+    }
+
+    public function event(): BelongsTo
+    {
+        return $this->belongsTo(Event::class);
+    }
+}

--- a/laravel/app/Models/Team.php
+++ b/laravel/app/Models/Team.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\HasManyThrough;
 
 class Team extends Model
 {
@@ -35,5 +36,15 @@ class Team extends Model
     public function affiliateUsers(): HasMany
     {
         return $this->hasMany(UserAffiliationTeam::class);
+    }
+
+    public function eventAffiliationTeams(): HasMany
+    {
+        return $this->hasMany(EventAffiliationTeam::class);
+    }
+
+    public function underwayEvents(): HasManyThrough
+    {
+        return $this->hasManyThrough(Event::class, EventAffiliationTeam::class);
     }
 }

--- a/laravel/app/UseCase/Event/CreateEvent.php
+++ b/laravel/app/UseCase/Event/CreateEvent.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\UseCase\Event;
+
+use App\Models\Event;
+use App\UseCase\UseCase;
+
+class CreateEvent extends UseCase
+{
+    public function execute(CreateEventInput $input)
+    {
+        $eventData = $input->getEventData();
+        $event = Event::create($eventData);
+
+        $event->eventAffiliationTeams()->create([
+            'team_id' => $input->getTeamId(),
+        ]);
+
+        return $event;
+    }
+}

--- a/laravel/app/UseCase/Event/CreateEventInput.php
+++ b/laravel/app/UseCase/Event/CreateEventInput.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\UseCase\Event;
+
+use Illuminate\Support\Arr;
+
+use App\UseCase\UseCaseInput;
+
+class CreateEventInput extends UseCaseInput
+{
+    protected function rules(): array
+    {
+        return [
+            'name' => 'required',
+            'team_id' => 'required'
+        ];
+    }
+
+    protected function attributes(): array
+    {
+        return [
+            'name' => 'イベント名',
+            'team_id' => 'チーム番号'
+        ];
+    }
+
+    public function getEventData(): array
+    {
+        $data = $this->toArray();
+        return Arr::except($data, ['team_id']);
+    }
+
+    public function getTeamId(): string
+    {
+        return $this->toArray()['team_id'];
+    }
+}

--- a/laravel/database/factories/EventAffiliationTeamFactory.php
+++ b/laravel/database/factories/EventAffiliationTeamFactory.php
@@ -4,18 +4,18 @@ namespace Database\Factories;
 
 use Illuminate\Database\Eloquent\Factories\Factory;
 
-use App\Models\UserAffiliationTeam;
-use App\Models\User;
+use App\Models\EventAffiliationTeam;
 use App\Models\Team;
+use App\Models\Event;
 
-class UserAffiliationTeamFactory extends Factory
+class EventAffiliationTeamFactory extends Factory
 {
     /**
      * The name of the factory's corresponding model.
      *
      * @var string
      */
-    protected $model = UserAffiliationTeam::class;
+    protected $model = EventAffiliationTeam::class;
 
     /**
      * Define the model's default state.
@@ -25,11 +25,11 @@ class UserAffiliationTeamFactory extends Factory
     public function definition()
     {
         $team = Team::inRandomOrder()->first();
-        $user = User::inRandomOrder()->first();
+        $event = Event::inRandomOrder()->first();
 
         return [
             'team_id' => $team->id,
-            'user_id' => $user->id,
+            'event_id' => $event->id,
         ];
     }
 }

--- a/laravel/database/migrations/2021_02_11_071556_event_affiliation_teams_migration.php
+++ b/laravel/database/migrations/2021_02_11_071556_event_affiliation_teams_migration.php
@@ -1,0 +1,41 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class EventAffiliationTeamsMigration extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('event_affiliation_teams', function (Blueprint $table) {
+            $table->uuid('id');
+            $table
+                ->foreignUuid('event_id')
+                ->constrained()
+                ->onUpdate('cascade')
+                ->onDelete('cascade');
+            $table
+                ->foreignUuid('team_id')
+                ->constrained()
+                ->onUpdate('cascade')
+                ->onDelete('cascade');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('event_affiliation_teams');
+    }
+}

--- a/laravel/graphql/event.graphql
+++ b/laravel/graphql/event.graphql
@@ -7,6 +7,7 @@ type Event {
 
 input EventInput {
     name: String!
+    team_id: ID!
 }
 
 extend type Mutation @guard {

--- a/laravel/tests/Graphql/EventTest.php
+++ b/laravel/tests/Graphql/EventTest.php
@@ -3,6 +3,9 @@
 namespace Tests\Graphql;
 
 use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Support\Arr;
+
+use App\Models\Team;
 
 // TODO: テスト用のDBを用意したら有効化する
 // use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -15,8 +18,11 @@ class EventTest extends TestCase
 
     public function testCreateEvent()
     {
+        $team = Team::factory()->create();
+
         $eventInput = [
             'name' => $this->faker->name,
+            'team_id' => $team->id,
         ];
 
         $response = $this
@@ -32,16 +38,24 @@ class EventTest extends TestCase
                 'input' => $eventInput
             ]);
 
+        $expectData = Arr::only($eventInput, ['name']);
+
         // 登録の確認
         $response
             ->assertStatus(200)
             ->assertJson([
                 'data' => [
-                    'createEvent' => $eventInput
+                    'createEvent' => $expectData
                 ]
             ]);
         $responseData = $response->json('data.createEvent');
         $this->assertIsUuid($responseData['id']);
         $this->assertDatabaseHas('events', $responseData);
+
+        $expectedAffiliation = [
+            'event_id' => $responseData['id'],
+            'team_id' => $eventInput['team_id']
+        ];
+        $this->assertDatabaseHas('event_affiliation_teams', $expectedAffiliation);
     }
 }


### PR DESCRIPTION
resolve: #36 

## この PR で実装される内容
イベントを登録した際にどのチームに所属するかが保存されるようになる
