### PR TITLE
#157 darkモードがオフの時に色がつかない部分がある不具合の修正

### DIFF
--- a/front/nuxt.config.js
+++ b/front/nuxt.config.js
@@ -88,7 +88,7 @@ export default {
           edit: colors.green.accent3,
           delete: colors.deepOrange.accent4,
           register: colors.blue.darken2,
-        }
+        },
       },
     },
   },

--- a/front/nuxt.config.js
+++ b/front/nuxt.config.js
@@ -84,6 +84,11 @@ export default {
           delete: colors.deepOrange.accent4,
           register: colors.blue.darken2,
         },
+        light: {
+          edit: colors.green.accent3,
+          delete: colors.deepOrange.accent4,
+          register: colors.blue.darken2,
+        }
       },
     },
   },


### PR DESCRIPTION
resolve: #157 

## この PR で実装される内容
darkモードがオフの時に色がつかない不具合が修正される

## 確認

-   [ ] ボタンの色がつくこと
![image](https://user-images.githubusercontent.com/8841932/161506956-7bc444be-59ed-42bf-8c2c-4b3e08276d87.png)

## 備考
