### PR TITLE
#162 care_about_circlesの紐づき先をcircles.idからcirlce_placements.idに変更

### DIFF
--- a/front/apollo/mutations/createCircleParticipatingInEvent.gql
+++ b/front/apollo/mutations/createCircleParticipatingInEvent.gql
@@ -3,6 +3,9 @@ mutation CreateCircleParticipatingInEventMutation(
 ) {
   createCircleParticipatingInEvent(input: $input) {
     id
-    name
+    circle {
+      id
+      name
+    }
   }
 }

--- a/front/apollo/mutations/updateCircleParticipatingInEvent.gql
+++ b/front/apollo/mutations/updateCircleParticipatingInEvent.gql
@@ -4,6 +4,9 @@ mutation UpdateCircleParticipatingInEventMutation(
 ) {
   updateCircleParticipatingInEvent(id: $id, input: $input) {
     id
-    name
+    circle {
+      id
+      name
+    }
   }
 }

--- a/front/components/circle-list/form/CircleForm.vue
+++ b/front/components/circle-list/form/CircleForm.vue
@@ -225,7 +225,7 @@ export default class CircleForm extends Vue {
       placement: this.circlePlacementInput as CirclePlacementInput,
     }
 
-    const circle = await this.$apollo
+    const circlePlacement = await this.$apollo
       .mutate({
         mutation: CreateCircleParticipatingInEventMutation,
         variables: { input },
@@ -240,7 +240,7 @@ export default class CircleForm extends Vue {
 
     const careAboutCircleInput: CareAboutCircleInput = {
       join_event_id: this.joinEventId,
-      circle_id: circle.id,
+      circle_placement_id: circlePlacement.id,
     }
     await this.$apollo
       .mutate({
@@ -254,7 +254,7 @@ export default class CircleForm extends Vue {
           this.validation.setBackendErrorsFromAppolo(error)
         }
       })
-    return circle
+    return circlePlacement.circle
   }
 
   private async updateCircle() {
@@ -271,7 +271,7 @@ export default class CircleForm extends Vue {
         variables: { id, input },
       })
       .then((res) => {
-        return res.data.updateCircleParticipatingInEvent
+        return res.data.updateCircleParticipatingInEvent.circle
       })
       .catch((error) => {
         if (isApolloError(error)) {

--- a/laravel/app/Models/CareAboutCircle.php
+++ b/laravel/app/Models/CareAboutCircle.php
@@ -9,11 +9,11 @@ class CareAboutCircle extends Model
 {
     use HasFactory;
 
-    protected $fillable = ['circle_id', 'join_event_id'];
+    protected $fillable = ['circle_placement_id', 'join_event_id'];
 
-    public function circle(): BelongsTo
+    public function circlePlacement(): BelongsTo
     {
-        return $this->belongsTo(Circle::class);
+        return $this->belongsTo(CirclePlacement::class);
     }
 
     public function joinEvent(): BelongsTo

--- a/laravel/app/Models/Circle.php
+++ b/laravel/app/Models/Circle.php
@@ -11,11 +11,6 @@ class Circle extends Model
 
     protected $fillable = ['name', 'kana', 'memo'];
 
-    public function careAboutCircles(): HasMany
-    {
-        return $this->hasMany(CareAboutCircle::class);
-    }
-
     public function circlePlacements(): HasMany
     {
         return $this->hasMany(CirclePlacement::class);

--- a/laravel/app/Models/CirclePlacement.php
+++ b/laravel/app/Models/CirclePlacement.php
@@ -33,6 +33,11 @@ class CirclePlacement extends Model
         return $this->belongsTo(EventDate::class);
     }
 
+    public function careAboutCircles(): HasMany
+    {
+        return $this->hasMany(CareAboutCircle::class);
+    }
+
     public function circleProducts(): HasMany
     {
         return $this->hasMany(CircleProduct::class);

--- a/laravel/app/UseCase/CareAboutCircle/CreateCareAboutCircleInput.php
+++ b/laravel/app/UseCase/CareAboutCircle/CreateCareAboutCircleInput.php
@@ -10,7 +10,7 @@ class CreateCareAboutCircleInput extends UseCaseInput
     {
         return [
             'join_event_id' => 'required',
-            'circle_id' => 'required',
+            'circle_placement_id' => 'required',
         ];
     }
 
@@ -18,7 +18,7 @@ class CreateCareAboutCircleInput extends UseCaseInput
     {
         return [
             'join_event_id' => 'イベント参加番号',
-            'circle_id' => 'サークル番号',
+            'circle_placement_id' => 'サークル配置番号',
         ];
     }
 }

--- a/laravel/app/UseCase/Circle/CreateCircleParticipatingInEvent.php
+++ b/laravel/app/UseCase/Circle/CreateCircleParticipatingInEvent.php
@@ -18,11 +18,11 @@ class CreateCircleParticipatingInEvent extends UseCase
 
             $placementData = $input->getPlacementData();
             $placementData['circle_id'] = $circle->id;
-            CirclePlacement::create($placementData);
+            $circlePlacement = CirclePlacement::create($placementData);
 
             $circle->refresh();
 
-            return $circle;
+            return $circlePlacement;
         });
 
         return $circle;

--- a/laravel/app/UseCase/Circle/UpdateCircleParticipatingInEvent.php
+++ b/laravel/app/UseCase/Circle/UpdateCircleParticipatingInEvent.php
@@ -25,8 +25,9 @@ class UpdateCircleParticipatingInEvent extends UseCase
             $circlePlacement->update($placementData);
 
             $circle->refresh();
+            $circlePlacement->refresh();
 
-            return $circle;
+            return $circlePlacement;
         });
 
         return $circle;

--- a/laravel/database/datasetFactories/CircleDatasetFactory.php
+++ b/laravel/database/datasetFactories/CircleDatasetFactory.php
@@ -26,12 +26,12 @@ class CircleDatasetFactory
         $joinEvent = $eventDataset['joinEvent'];
         $circlePlacementFactory = CirclePlacement::factory()
             ->state(['event_date_id' => $event->eventDates->random()->id])
-            ->hasCircleProducts(1);
-        $circle = Circle::factory($this->numberOfCreate)
-            ->has($circlePlacementFactory)
+            ->hasCircleProducts(1)
             ->hasCareAboutCircles(1, [
                 'join_event_id' => $joinEvent->id,
-            ])
+            ]);
+        $circle = Circle::factory($this->numberOfCreate)
+            ->has($circlePlacementFactory)
             ->create();
         return array_merge($eventDataset, compact('circle'));
     }

--- a/laravel/database/factories/CareAboutCircleFactory.php
+++ b/laravel/database/factories/CareAboutCircleFactory.php
@@ -5,7 +5,7 @@ namespace Database\Factories;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 use App\Models\CareAboutCircle;
-use App\Models\Circle;
+use App\Models\CirclePlacement;
 use App\Models\JoinEvent;
 
 class CareAboutCircleFactory extends Factory
@@ -25,7 +25,7 @@ class CareAboutCircleFactory extends Factory
     public function definition()
     {
         return [
-            'circle_id' => Circle::factory(),
+            'circle_placement_id' => CirclePlacement::factory(),
             'join_event_id' => JoinEvent::factory(),
         ];
     }

--- a/laravel/database/migrations/2021_04_22_125700_create_care_about_circles_table.php
+++ b/laravel/database/migrations/2021_04_22_125700_create_care_about_circles_table.php
@@ -22,7 +22,7 @@ class CreateCareAboutCirclesTable extends Migration
                 ->onUpdate('cascade')
                 ->onDelete('cascade');
             $table
-                ->foreignUuid('circle_id')
+                ->foreignUuid('circle_placement_id')
                 ->constrained()
                 ->onUpdate('cascade')
                 ->onDelete('cascade');

--- a/laravel/graphql/careAboutCircle.graphql
+++ b/laravel/graphql/careAboutCircle.graphql
@@ -2,14 +2,14 @@ type CareAboutCircle {
     id: ID!
     join_event_id: ID!
     joinEvent: JoinEvent @belongsTo
-    circle: Circle @belongsTo
+    circlePlacement: CirclePlacement @belongsTo
     created_at: DateTime
     updated_at: DateTime
 }
 
 input CareAboutCircleInput {
     join_event_id: ID!
-    circle_id: ID!
+    circle_placement_id: ID!
 }
 
 extend type Mutation @guard {

--- a/laravel/graphql/circle.graphql
+++ b/laravel/graphql/circle.graphql
@@ -31,14 +31,14 @@ extend type Mutation @guard {
         )
     createCircleParticipatingInEvent(
         input: CreateCircleParticipatingInEventInput! @spread
-    ): Circle!
+    ): CirclePlacement!
         @field(
             resolver: "App\\GraphQL\\Mutations\\CreateCircleParticipatingInEvent"
         )
     updateCircleParticipatingInEvent(
         id: ID!,
         input: CreateCircleParticipatingInEventInput! @spread
-    ): Circle!
+    ): CirclePlacement!
         @field(
             resolver: "App\\GraphQL\\Mutations\\UpdateCircleParticipatingInEvent"
         )

--- a/laravel/tests/Graphql/CareAboutCircleTest.php
+++ b/laravel/tests/Graphql/CareAboutCircleTest.php
@@ -6,6 +6,7 @@ use Illuminate\Foundation\Testing\WithFaker;
 use Illuminate\Support\Arr;
 
 use App\Models\Circle;
+use App\Models\CirclePlacement;
 use App\Models\Event;
 use App\Models\EventDate;
 use App\Models\Team;
@@ -46,10 +47,14 @@ class CareAboutCircleTest extends TestCase
         ])->create();
         $circlePlacementClassification = $team->circlePlacementClassifications()->inRandomOrder()->first();
         $circle = Circle::factory()->create();
+        $circlePlacement = CirclePlacement::factory([
+            'circle_id' => $circle->id,
+            'event_date_id' => $eventDate->id,
+        ])->create();
 
 
         $createCircleParticipatingInEventInput = [
-            'circle_id' => $circle->id,
+            'circle_placement_id' => $circlePlacement->id,
             'join_event_id' => $joinEvent->id,
         ];
 
@@ -59,7 +64,7 @@ class CareAboutCircleTest extends TestCase
                 mutation createCareAboutCircle($input: CareAboutCircleInput!) {
                     createCareAboutCircle(input: $input) {
                         id
-                        circle {
+                        circlePlacement {
                             id
                         }
                         joinEvent {
@@ -76,8 +81,8 @@ class CareAboutCircleTest extends TestCase
             ->assertJson([
                 'data' => [
                     'createCareAboutCircle' => [
-                        'circle' => [
-                            'id' => $circle->id,
+                        'circlePlacement' => [
+                            'id' => $circlePlacement->id,
                         ],
                         'joinEvent' => [
                             'id' => $joinEvent->id,

--- a/laravel/tests/Graphql/CircleTest.php
+++ b/laravel/tests/Graphql/CircleTest.php
@@ -6,6 +6,7 @@ use Illuminate\Foundation\Testing\WithFaker;
 use Illuminate\Support\Arr;
 
 use App\Models\Circle;
+use App\Models\CirclePlacement;
 use App\Models\Event;
 use App\Models\EventDate;
 use App\Models\Team;
@@ -68,9 +69,12 @@ class CircleTest extends TestCase
                 mutation createCircleParticipatingInEvent($input: CreateCircleParticipatingInEventInput!) {
                     createCircleParticipatingInEvent(input: $input) {
                         id
-                        name
-                        kana
-                        memo
+                        circle {
+                            id
+                            name
+                            kana
+                            memo
+                        }
                     }
                 }
             ', [
@@ -82,14 +86,16 @@ class CircleTest extends TestCase
             ->assertStatus(200)
             ->assertJson([
                 'data' => [
-                    'createCircleParticipatingInEvent' => $expectedCircleData,
-                ]
+                    'createCircleParticipatingInEvent' => [
+                        'circle' => $expectedCircleData,
+                    ],
+                ],
             ]);
         $responseData = $response->json('data.createCircleParticipatingInEvent');
 
-        $circle = Circle::findOrFail($responseData['id']);
+        $circle = Circle::findOrFail($responseData['circle']['id']);
 
-        $placement = $circle->circlePlacements()->first();
+        $placement = CirclePlacement::findOrFail($responseData['id']);
         $expectedPlacement = $createCircleParticipatingInEventInput['placement'];
         $expectedPlacement['circle_id'] = $circle->id;
         $assertionPlacement = Arr::except($placement->toArray(), ['id', 'created_at', 'updated_at']);


### PR DESCRIPTION
resolve: #162 

## この PR で実装される内容
circlesの紐づき先がcirclesからcircle_placementsになる

## 悩ましい（見てほしい）部分

## 確認

-   [ ] サークル登録ができること
![image](https://user-images.githubusercontent.com/8841932/162179670-886127a3-f660-4595-ab3e-cc91a337fbe3.png)

## 備考
