### PR TITLE
#135 ModelのFactory、Relationがエラーをはかないかどうかのテストを実装

### DIFF
--- a/laravel/app/Models/Model.php
+++ b/laravel/app/Models/Model.php
@@ -6,7 +6,7 @@ use Illuminate\Database\Eloquent\Model as BaseModel;
 
 use App\Models\Traits\PrimaryKeyUuidUsable;
 
-class Model extends BaseModel
+abstract class Model extends BaseModel
 {
     use PrimaryKeyUuidUsable;
 

--- a/laravel/tests/Helpers/ClassEnumerator.php
+++ b/laravel/tests/Helpers/ClassEnumerator.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Tests\Helpers;
+
+use ReflectionClass;
+use Illuminate\Support\Collection;
+
+class ClassEnumerator
+{
+    public function enumerateClassesInDirectory(string $directory): Collection
+    {
+        return collect(glob("{$directory}/*.php"))
+            ->map(function ($file) {
+                $fileWithoutBasePath = str_replace(base_path() . '/', '', $file);
+                $fileWithoutBasePathAndExtension = str_replace('.php', '', $fileWithoutBasePath);
+                return '\\' . ucfirst(str_replace('/', '\\', $fileWithoutBasePathAndExtension));
+            })->filter(function ($class) {
+                return class_exists($class);
+            })->filter(function ($class) {
+                $reflectionClass = new ReflectionClass($class);
+                return $reflectionClass->isInstantiable();
+            })
+            ->values();
+    }
+}

--- a/laravel/tests/Unit/AllModelTest.php
+++ b/laravel/tests/Unit/AllModelTest.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Tests\Unit;
+
+use ReflectionClass;
+use ReflectionMethod;
+
+use Illuminate\Database\Eloquent\Collection as EloquentCollection;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\Relation;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Collection;
+
+use Tests\TestCase;
+use Tests\Helpers\ClassEnumerator;
+
+class AllModelTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * @dataProvider hasFactoryModelClasses
+     */
+    public function testModelFactory($model)
+    {
+        $factory = $model::factory();
+        $instance = $factory->create();
+        $this->assertTrue($instance instanceof $model);
+    }
+
+    /**
+     * @dataProvider hasFactoryModelClasses
+     */
+    public function testModelRelations($modelClass)
+    {
+        $model = $modelClass::factory()->create();
+
+        $this->extractRelationMethodReflections($modelClass)
+            ->each(function (ReflectionMethod $reflectionMethod) use ($model) {
+                $relation = $reflectionMethod->invoke($model);
+                $relatedModel = $relation->getRelated();
+
+                $relationName = $reflectionMethod->getName();
+                $relationResult = $model->$relationName;
+                $relationResultFirst = $relationResult instanceof EloquentCollection ? $relationResult->first() : $relationResult;
+
+                // note: リレーション先のレコードが存在しない場合があるので、nullは成功として扱っている
+                //       とりあえず問題なくクエリが叩けているかどうかのテストを行っている
+                $isNull = is_null($relationResultFirst);
+                $isRelated = $relationResultFirst instanceof $relatedModel;
+                $this->assertTrue($isNull || $isRelated);
+            });
+    }
+
+    private function extractRelationMethodReflections(string $modelClass): Collection
+    {
+        $reflectionClass = new ReflectionClass($modelClass);
+        return collect($reflectionClass->getMethods(ReflectionMethod::IS_PUBLIC))
+            ->reject(function (ReflectionMethod $reflectionMethod) {
+                $isAbstract = $reflectionMethod->isAbstract();
+                $hasRequiredArgument = $reflectionMethod->getNumberOfRequiredParameters() > 0;
+                return $isAbstract || $hasRequiredArgument;
+            })
+            ->filter(function (ReflectionMethod $reflectionMethod) {
+                $returnType = $reflectionMethod->getReturnType();
+                return !is_null($returnType) && is_subclass_of($returnType->getName(), Relation::class);
+            });
+    }
+
+    public function hasFactoryModelClasses(): array
+    {
+        $this->createApplication();
+
+        $classEnumerator = new ClassEnumerator();
+        return $classEnumerator->enumerateClassesInDirectory(app_path('Models'))
+            ->filter(function ($model) {
+                $useTraits = trait_uses_recursive($model);
+                return in_array(HasFactory::class, $useTraits);
+            })
+            ->values()
+            ->mapWithKeys(function ($model) {
+                return [$model => [$model]];
+            })->toArray();
+    }
+}


### PR DESCRIPTION
resolve: #135 

## この PR で実装される内容
`App\Models\` 配下のFactoryを持つ具象ModelのFactoryで対象Modelをエラーなくcreateできるかのテストが追加される
同様に引数を持たないRelationに紐づくModelをエラーなく取得できるかのテストが追加される

## 確認

-   [x] テストが実行され、通ること


## 備考
