### PR TITLE
#176 vuexの導入

### DIFF
--- a/front/components/circle-list/CircleListTable.vue
+++ b/front/components/circle-list/CircleListTable.vue
@@ -35,7 +35,6 @@
     </template>
     <template v-slot:item.circle_name="{ item }">
       <favorite-button
-        :user-id="userId"
         :circle-id="item.circle_id"
         :favorite="findFavorite(item.circle_id)"
         @update-favorite="$emit('update-favorite')"
@@ -97,12 +96,6 @@ export default class CircleListTable extends Vue {
     required: true,
   })
   private filterConditionItems!: FilterConditionItems
-
-  @Prop({
-    type: String,
-    required: true,
-  })
-  userId!: string
 
   @Prop({
     type: Array as PropType<Favorite[]>,

--- a/front/components/favorites/FavoriteButton.vue
+++ b/front/components/favorites/FavoriteButton.vue
@@ -12,7 +12,7 @@ import {
   CreateFavoriteMutation,
   DeleteFavoriteMutation,
 } from '~/apollo/graphql'
-import { userStore } from '~/utils/store-accessor'
+import { userStore } from '~/store'
 
 @Component({ inheritAttrs: false })
 export default class FavoriteButton extends Vue {

--- a/front/components/favorites/FavoriteButton.vue
+++ b/front/components/favorites/FavoriteButton.vue
@@ -12,6 +12,7 @@ import {
   CreateFavoriteMutation,
   DeleteFavoriteMutation,
 } from '~/apollo/graphql'
+import { userStore } from '~/utils/store-accessor'
 
 @Component({ inheritAttrs: false })
 export default class FavoriteButton extends Vue {
@@ -26,13 +27,11 @@ export default class FavoriteButton extends Vue {
     type: String,
     required: true,
   })
-  private userId!: string
-
-  @Prop({
-    type: String,
-    required: true,
-  })
   private circleId!: string
+
+  private get userId(): string {
+    return userStore.loginUserOrEmptyUser.id
+  }
 
   private get isFavorite(): boolean {
     return Boolean(this.favorite)

--- a/front/layouts/default.vue
+++ b/front/layouts/default.vue
@@ -73,7 +73,7 @@ type UnderwayCircleListItem = {
 
 @Component({
   apollo: {
-    user: {
+    me: {
       query: MeQuery,
       skip() {
         return !this.$apolloHelpers.getToken()

--- a/front/layouts/default.vue
+++ b/front/layouts/default.vue
@@ -64,6 +64,7 @@ import {
   LogoutMutation,
   UnderwayEventsForJoinedTeamsQuery,
 } from '~/apollo/graphql'
+import { userStore } from '~/utils/store-accessor'
 
 type UnderwayCircleListItem = {
   team: Team
@@ -77,8 +78,10 @@ type UnderwayCircleListItem = {
       skip() {
         return !this.$apolloHelpers.getToken()
       },
-      update(data): User {
-        return data.me
+      // note: resultで自前で定義することで、computed setを呼び出し、
+      //       vuexStoreへ直接書き出しを行えるようにしている
+      result(result) {
+        this.user = result?.data?.me || null
       },
     },
     underwayCircleListItems: {
@@ -116,8 +119,6 @@ export default class DefaultLayout extends Vue {
     team_name: string // eslint-disable-line camelcase
   }[] = [{ event_id: 'aaa', event_name: 'event', team_name: 'team' }]
 
-  user: User | null = null
-
   private logout(): void {
     this.$apollo
       .mutate({
@@ -139,6 +140,18 @@ export default class DefaultLayout extends Vue {
   set isDark(dark) {
     if (this?.$vuetify?.theme?.dark !== undefined) {
       this.$vuetify.theme.dark = dark
+    }
+  }
+
+  private get user(): User | null {
+    return userStore.loginUser
+  }
+
+  private set user(user: User | null) {
+    if (user) {
+      userStore.setLoginUser(user)
+    } else {
+      userStore.logout()
     }
   }
 }

--- a/front/layouts/default.vue
+++ b/front/layouts/default.vue
@@ -64,7 +64,7 @@ import {
   LogoutMutation,
   UnderwayEventsForJoinedTeamsQuery,
 } from '~/apollo/graphql'
-import { userStore } from '~/utils/store-accessor'
+import { userStore } from '~/store'
 
 type UnderwayCircleListItem = {
   team: Team

--- a/front/pages/login.vue
+++ b/front/pages/login.vue
@@ -29,8 +29,9 @@
 <script lang="ts">
 import { Vue, Component } from 'nuxt-property-decorator'
 import { ValidationObserver } from 'vee-validate'
-import { LoginMutation, LoginInput, LoginData } from '~/apollo/graphql'
+import { LoginMutation, LoginInput, LoginData, MeQuery } from '~/apollo/graphql'
 import { LoginValidation } from '~/validation/loginValidation'
+import { userStore } from '~/utils/store-accessor'
 
 @Component({})
 export default class Login extends Vue {
@@ -71,8 +72,18 @@ export default class Login extends Vue {
     if (token) {
       this.$toast.success('ログインしました')
       await this.$apolloHelpers.onLogin(token)
+      const loginUser = await this.fetchLoginUser()
+      userStore.setLoginUser(loginUser)
       this.$router.push('/')
     }
+  }
+
+  private async fetchLoginUser() {
+    return this.$apollo
+      .query({
+        query: MeQuery,
+      })
+      .then((result) => result.data.me)
   }
 }
 </script>

--- a/front/pages/login.vue
+++ b/front/pages/login.vue
@@ -74,12 +74,12 @@ export default class Login extends Vue {
       await this.$apolloHelpers.onLogin(token)
       const loginUser = await this.fetchLoginUser()
       userStore.setLoginUser(loginUser)
-      this.$router.push('/')
+      this.$router.push('/mypage')
     }
   }
 
   private async fetchLoginUser() {
-    return this.$apollo
+    return await this.$apollo
       .query({
         query: MeQuery,
       })

--- a/front/pages/mypage/index.vue
+++ b/front/pages/mypage/index.vue
@@ -42,7 +42,7 @@
 <script lang="ts">
 import { Vue, Component } from 'nuxt-property-decorator'
 import { User } from '~/apollo/graphql'
-import { userStore } from '~/utils/store-accessor'
+import { userStore } from '~/store'
 
 @Component({})
 export default class MyPage extends Vue {

--- a/front/pages/mypage/index.vue
+++ b/front/pages/mypage/index.vue
@@ -41,26 +41,13 @@
 
 <script lang="ts">
 import { Vue, Component } from 'nuxt-property-decorator'
-import { User, MeQuery } from '~/apollo/graphql'
+import { User } from '~/apollo/graphql'
+import { userStore } from '~/utils/store-accessor'
 
-@Component({
-  apollo: {
-    user: {
-      query: MeQuery,
-      update(data) {
-        return data.me
-      },
-    },
-  },
-})
+@Component({})
 export default class MyPage extends Vue {
-  private user: User = {
-    id: '',
-    name: '',
-    name_kana: '',
-    handle_name: '',
-    handle_name_kana: '',
-    affiliateTeams: [],
+  private get user(): User {
+    return userStore.loginUserOrEmptyUser
   }
 }
 </script>

--- a/front/pages/teams/_team_id/events/_event_id/circle-list.vue
+++ b/front/pages/teams/_team_id/events/_event_id/circle-list.vue
@@ -41,7 +41,6 @@
       :circle-lists="circleLists"
       :table-state="circleListState"
       :filter-condition-items="circleListTableFilterConditionItems"
-      :user-id="user.id"
       :favorites="myFavorites"
       @update-favorite="onUpdateFavorite"
       @open-circle-list-form="openCircleListForm"
@@ -59,10 +58,9 @@ import {
   EventDate,
   JoinEvent,
   JoinEventCircleListsQuery,
-  User,
   EventWithDateQuery,
   FindJoinEventWithDateQuery,
-  MeQuery,
+  User,
   WantPrioritiesQuery,
   CirclePlacementClassificationsQuery,
   WantPriority,
@@ -79,6 +77,7 @@ import { FilterConditionItems } from '~/components/circle-list/table/filters/fil
 import TableStateInterface from '~/components/circle-list/table/TableStateInterface'
 import MyCircleListTableState from '~/components/circle-list/table/MyCircleListTableState'
 import TeamCircleListTableState from '~/components/circle-list/table/TeamCircleListTableState'
+import { userStore } from '~/utils/store-accessor'
 
 type CircleListTab = {
   key: string
@@ -97,13 +96,6 @@ type CircleListTab = {
       variables() {
         const eventId: string = this.$route.params.event_id
         return { id: eventId }
-      },
-    },
-    // TODO: 全体でログイン情報は共有する
-    user: {
-      query: MeQuery,
-      update(data) {
-        return data.me
       },
     },
     joinEvent: {
@@ -203,11 +195,6 @@ export default class CircleListPage extends Vue {
 
   private isOpenJoinEventForm: Boolean = false
 
-  private user: User = {
-    id: '',
-    name: '',
-  }
-
   private joinEvent: JoinEvent | null = null
 
   private myCircleLists: CircleList[] = []
@@ -236,6 +223,10 @@ export default class CircleListPage extends Vue {
       label: '全体リスト',
     },
   ]
+
+  private get user(): User {
+    return userStore.loginUserOrEmptyUser
+  }
 
   private get circleListState(): TableStateInterface {
     const circleListStateMap: { [key: string]: TableStateInterface } = {

--- a/front/store/index.ts
+++ b/front/store/index.ts
@@ -1,0 +1,9 @@
+// docs: https://github.com/championswimmer/vuex-module-decorators#accessing-modules-with-nuxtjs
+// note: vuexではなく、apolloのlocalStateを使う方法もあるが、オブジェクトを保持したい場合に、
+//       Mutationの引数のinputを毎回しているする必要がある（＋tsファイルからimportできない）ことが不便なので、
+//       本プロジェクトではvuexを使っている。（いい方法があれば、変わるかも）
+import { Store } from 'vuex'
+import { initializeStores } from '~/utils/store-accessor'
+const initializer = (store: Store<any>) => initializeStores(store)
+export const plugins = [initializer]
+export * from '~/utils/store-accessor'

--- a/front/store/user.ts
+++ b/front/store/user.ts
@@ -1,0 +1,29 @@
+import { VuexModule, VuexMutation, Module } from 'nuxt-property-decorator'
+import { User } from '~/apollo/graphql'
+
+export interface UserState {
+  loginUser: User | null
+}
+
+@Module({
+  name: 'user',
+  stateFactory: true,
+  namespaced: true,
+})
+export default class UserModule extends VuexModule implements UserState {
+  private _loginUser: User | null = null
+
+  get loginUser(): User | null {
+    return this._loginUser
+  }
+
+  @VuexMutation
+  public setLoginUser(user: User) {
+    this._loginUser = user
+  }
+
+  @VuexMutation
+  public logout() {
+    this._loginUser = null
+  }
+}

--- a/front/store/user.ts
+++ b/front/store/user.ts
@@ -5,6 +5,15 @@ export interface UserState {
   loginUser: User | null
 }
 
+const emptyUser: User = {
+  id: '',
+  name: '',
+  name_kana: '',
+  handle_name: '',
+  handle_name_kana: '',
+  affiliateTeams: [],
+}
+
 @Module({
   name: 'user',
   stateFactory: true,
@@ -15,6 +24,10 @@ export default class UserModule extends VuexModule implements UserState {
 
   get loginUser(): User | null {
     return this._loginUser
+  }
+
+  get loginUserOrEmptyUser(): User {
+    return this._loginUser || emptyUser
   }
 
   @VuexMutation

--- a/front/store/user.ts
+++ b/front/store/user.ts
@@ -1,10 +1,6 @@
 import { VuexModule, VuexMutation, Module } from 'nuxt-property-decorator'
 import { User } from '~/apollo/graphql'
 
-export interface UserState {
-  loginUser: User | null
-}
-
 const emptyUser: User = {
   id: '',
   name: '',
@@ -19,24 +15,24 @@ const emptyUser: User = {
   stateFactory: true,
   namespaced: true,
 })
-export default class UserModule extends VuexModule implements UserState {
+export default class UserModule extends VuexModule {
   private _loginUser: User | null = null
 
-  get loginUser(): User | null {
+  public get loginUser(): User | null {
     return this._loginUser
   }
 
-  get loginUserOrEmptyUser(): User {
+  public get loginUserOrEmptyUser(): User {
     return this._loginUser || emptyUser
   }
 
   @VuexMutation
-  public setLoginUser(user: User) {
+  public setLoginUser(user: User): void {
     this._loginUser = user
   }
 
   @VuexMutation
-  public logout() {
+  public logout(): void {
     this._loginUser = null
   }
 }

--- a/front/test/layouts/defaultLayout.spec.ts
+++ b/front/test/layouts/defaultLayout.spec.ts
@@ -4,9 +4,11 @@ import DefaultLayout from '~/layouts/default.vue'
 import UserFactory from '~/test/factory/UserFactory'
 import EventFactory from '~/test/factory/EventFactory'
 import TeamFactory from '~/test/factory/TeamFactory'
+import { resetStore, store } from '~/test/utils/vuex-store'
 
 const makeWrapper = () => {
   return mount(DefaultLayout, {
+    store,
     stubs: [
       'nuxt-link',
       'v-app',
@@ -21,6 +23,10 @@ const makeWrapper = () => {
 }
 
 describe('default layout', () => {
+  beforeEach(() => {
+    resetStore()
+  })
+
   test('display during logout', async () => {
     const wrapper = makeWrapper()
 

--- a/front/test/pages/login.spec.ts
+++ b/front/test/pages/login.spec.ts
@@ -2,11 +2,17 @@ import { mount } from '@vue/test-utils'
 import flushPromises from 'flush-promises'
 import Login from '~/pages/login.vue'
 import { LoginInput } from '~/apollo/graphql'
+import UserFactory from '~/test/factory/UserFactory'
+import { User } from 'apollo/graphql'
+import { resetStore, store, userStore } from '~/test/utils/vuex-store'
 
 describe('login page', () => {
+  beforeEach(() => {
+    resetStore()
+  })
+
   test('success login test', async () => {
     const token: string = 'testtoken'
-
     const mutate = jest.fn((option) => ({
       data: {
         login: {
@@ -14,14 +20,24 @@ describe('login page', () => {
         },
       },
     }))
+
+    const user: User = new UserFactory().make()
+    const query = jest.fn(async () => ({
+      data: {
+        me: user,
+      },
+    }))
+
     const onLogin = jest.fn()
     const push = jest.fn()
     const success = jest.fn()
 
     const wrapper = mount(Login, {
+      store,
       mocks: {
         $apollo: {
           mutate,
+          query,
         },
         $apolloHelpers: {
           onLogin,
@@ -54,7 +70,8 @@ describe('login page', () => {
     expect(onLogin).toBeCalled()
     expect(onLogin.mock.calls[0][0]).toBe(token)
     expect(push).toBeCalled()
-    expect(push.mock.calls[0][0]).toBe('/')
+    expect(push.mock.calls[0][0]).toBe('/mypage')
     expect(success).toBeCalled()
+    expect(userStore.loginUser?.id || null).toBe(user.id)
   })
 })

--- a/front/test/pages/mypage/index.spec.ts
+++ b/front/test/pages/mypage/index.spec.ts
@@ -3,8 +3,13 @@ import flushPromises from 'flush-promises'
 import MyPage from '~/pages/mypage/index.vue'
 import UserFactory from '~/test/factory/UserFactory'
 import TeamFactory from '~/test/factory/TeamFactory'
+import { store, resetStore, userStore } from '~/test/utils/vuex-store'
 
 describe('my page index', () => {
+  beforeEach(() => {
+    resetStore()
+  })
+
   test('see contents', async () => {
     const user = new UserFactory().make()
     const team = new TeamFactory().make()
@@ -15,12 +20,10 @@ describe('my page index', () => {
       },
     ]
 
+    userStore.setLoginUser(user)
     const wrapper = mount(MyPage, {
+      store,
       stubs: ['nuxt-link'],
-    })
-
-    wrapper.setData({
-      user,
     })
     await flushPromises()
 

--- a/front/test/setup.js
+++ b/front/test/setup.js
@@ -1,4 +1,5 @@
 import Vue from 'vue'
+import Vuex from 'vuex'
 import Vuetify from 'vuetify'
 import {
   extend,
@@ -11,6 +12,7 @@ import VValidateTextField from '~/components/form/VValidateTextField.vue'
 import '~/vee-validate/password'
 
 Vue.use(Vuetify)
+Vue.use(Vuex)
 
 localize({ ja })
 localize('ja')

--- a/front/test/utils/vuex-store.ts
+++ b/front/test/utils/vuex-store.ts
@@ -1,0 +1,21 @@
+import Vuex, { Store } from 'vuex'
+import { initializeStores } from '~/store'
+import UserStoreModule from '~/store/user'
+
+let store: Store<any>
+
+// note: beforeEachで毎回呼び出すことで、テストごとにvuexのstoreをresetできる
+// note: storeの数が増えるようであれば、登録するmodulesを引数で受け取る感じにしてもいいかも。
+//       また、mockしたstoreを受け取れるようにするのもいいかもしれない。
+const resetStore = () => {
+  store = new Vuex.Store({
+    modules: {
+      user: UserStoreModule,
+    },
+  })
+  initializeStores(store)
+}
+
+// note: mountにstoreを渡すことで、mountしたvueインスタンスからvuexのstoreが参照できるようになる
+export { resetStore, store }
+export * from '~/store'

--- a/front/utils/store-accessor.ts
+++ b/front/utils/store-accessor.ts
@@ -1,0 +1,12 @@
+// docs: https://github.com/championswimmer/vuex-module-decorators#accessing-modules-with-nuxtjs
+import { Store } from 'vuex'
+import { getModule } from 'vuex-module-decorators'
+import UserModule from '~/store/user'
+
+let userStore: UserModule
+
+function initializeStores(store: Store<any>): void {
+  userStore = getModule(UserModule, store)
+}
+
+export { initializeStores, userStore }


### PR DESCRIPTION
resolve: #176

## この PR で実装される内容
ログインユーザの管理にvuexが使用される
ログイン時にヘッダーが更新されるようになる

## 確認

-   [x] ログインでき、ヘッダーがログイン中のものに変更されること
![cd216728-5109-484e-a3fe-822d8f6fbab3](https://user-images.githubusercontent.com/8841932/165920799-af4c3207-653e-41db-a938-d68adf83799b.gif)

-   [x] お気に入りの登録/解除/表示ができること
![210c4b33-9a4d-4e8b-9ac6-afb380bec736](https://user-images.githubusercontent.com/8841932/165921231-5bcfed97-b94d-46b1-9439-088395ec3789.gif)


## 備考
