### PR TITLE
#61 サークルリスト画面から各種情報の編集、欲しいものの追加ができるようにする

### DIFF
--- a/front/components/circle-list/CircleListForm.vue
+++ b/front/components/circle-list/CircleListForm.vue
@@ -56,7 +56,7 @@
 </template>
 
 <script lang="ts">
-import { Vue, Prop, PropSync, Component } from 'nuxt-property-decorator'
+import { Vue, Prop, PropSync, Component, Watch } from 'nuxt-property-decorator'
 import CircleForm from './form/CircleForm.vue'
 import CircleProductForm from './form/CircleProductForm.vue'
 import {
@@ -103,6 +103,9 @@ export default class CircleListForm extends Vue {
   @Prop({ type: String })
   private joinEventId!: String | null
 
+  @Prop({ type: String, default: null })
+  private editingCircleId!: String | null
+
   private isEditCircle: boolean = true
 
   private circleId: String | null = null
@@ -113,6 +116,11 @@ export default class CircleListForm extends Vue {
 
   private editingCircleProduct: CircleProduct | null = null
 
+  private readonly nullCircle: Circle = {
+    id: '',
+    name: '',
+  }
+
   private get circle(): Circle {
     return this.circlePlacement?.circle ?? this.nullCircle
   }
@@ -121,9 +129,23 @@ export default class CircleListForm extends Vue {
     return this.circlePlacement?.circleProducts ?? []
   }
 
-  private readonly nullCircle: Circle = {
-    id: '',
-    name: '',
+  @Watch('editingCircleId')
+  private onUpdateEditingCircleId(editingCircleId: string | null): void {
+    this.cancelCircleProduct()
+    editingCircleId
+      ? this.initializeDisplayCircle(editingCircleId)
+      : this.clearForm()
+  }
+
+  private clearForm(): void {
+    this.isEditCircle = true
+    this.circleId = null
+    this.circlePlacement = null
+  }
+
+  private initializeDisplayCircle(editingCircleId: string): void {
+    this.isEditCircle = false
+    this.circleId = editingCircleId
   }
 
   private onSavedCircle({ circle }: any): void {
@@ -161,6 +183,7 @@ export default class CircleListForm extends Vue {
 
     this.$toast.success('削除しました')
     this.$apollo.queries.circlePlacement.refetch()
+    this.$emit('saved')
   }
 
   private onSavedCircleProduct(): void {

--- a/front/components/circle-list/CircleListTable.vue
+++ b/front/components/circle-list/CircleListTable.vue
@@ -7,6 +7,7 @@
     disable-pagination
     fixed-header
     multi-sort
+    @dblclick:row="openCircleListForm"
   >
     <template v-slot:top>
       <v-toolbar>
@@ -134,7 +135,10 @@ export default class CircleListTable extends Vue {
   }
 
   @Emit()
-  private openCircleListForm() {}
+  private openCircleListForm(_: any, row?: { item: CircleList }) {
+    const circleList = row?.item || null
+    return circleList
+  }
 
   private toggleShowFilter(): void {
     this.isShowFilter = !this.isShowFilter

--- a/front/pages/teams/_team_id/events/_event_id/circle-list.vue
+++ b/front/pages/teams/_team_id/events/_event_id/circle-list.vue
@@ -286,7 +286,7 @@ export default class CircleListPage extends Vue {
   }
 
   private openCircleListForm(circleList: CircleList | null): void {
-    this.editingCircleId = circleList?.circle_id ?? null
+    this.editingCircleId = circleList?.circle_id ?? null // eslint-disable-line camelcase
     this.isOpenCircleListForm = true
   }
 

--- a/front/pages/teams/_team_id/events/_event_id/circle-list.vue
+++ b/front/pages/teams/_team_id/events/_event_id/circle-list.vue
@@ -29,6 +29,7 @@
       :event-id="$route.params.event_id"
       :team-id="$route.params.team_id"
       :join-event-id="joinEvent ? joinEvent.id : null"
+      :editing-circle-id="editingCircleId"
       @saved="onSavedCircle"
     />
 
@@ -77,7 +78,7 @@ import { FilterConditionItems } from '~/components/circle-list/table/filters/fil
 import TableStateInterface from '~/components/circle-list/table/TableStateInterface'
 import MyCircleListTableState from '~/components/circle-list/table/MyCircleListTableState'
 import TeamCircleListTableState from '~/components/circle-list/table/TeamCircleListTableState'
-import { userStore } from '~/utils/store-accessor'
+import { userStore } from '~/store'
 
 type CircleListTab = {
   key: string
@@ -209,6 +210,8 @@ export default class CircleListPage extends Vue {
 
   private isOpenCircleListForm: boolean = false
 
+  private editingCircleId: String | null = null
+
   private selectedCircleListTabIndex: number = 0
 
   private myFavorites: Favorite[] = []
@@ -282,7 +285,8 @@ export default class CircleListPage extends Vue {
     this.$apollo.queries.joinEvent.refetch()
   }
 
-  private openCircleListForm(): void {
+  private openCircleListForm(circleList: CircleList | null): void {
+    this.editingCircleId = circleList?.circle_id ?? null
     this.isOpenCircleListForm = true
   }
 


### PR DESCRIPTION
resolve: #61 

## この PR で実装される内容
サークルリストの一覧からサークルリスト編集ダイアログを表示、編集できるようになる

（ついでの不具合修正）
頒布物削除時にサークルリスト一覧が更新されるようになる

## 確認

-   [x] サークルリスト一覧の行をダブルクリックすると、該当のサークルの編集ダイアログが表示されること
- [x] 頒布物削除時にサークルリスト一覧が更新されること
![7a03ed45-9f4b-4aa1-b4fd-0903c1071108](https://user-images.githubusercontent.com/8841932/166144438-5adc761a-2494-4677-9672-da763be6c983.gif)


## 備考
