### PR TITLE
#183 feat: サークルリスト編集ダイアログにお気に入りボタンを追加する

### DIFF
--- a/front/components/circle-list/CircleListForm.vue
+++ b/front/components/circle-list/CircleListForm.vue
@@ -4,6 +4,11 @@
       <v-card-title>
         <template v-if="isEditCircle">サークルリスト編集</template>
         <template v-else>
+          <favorite-button
+            v-if="circleId"
+            :circleId="circleId"
+            @update-favorite="$emit('update-favorite')"
+          />
           {{ circlePlacement ? circlePlacement.formatted_placement : '' }}
           {{ circle.name }}
           <v-spacer />
@@ -59,6 +64,7 @@
 import { Vue, Prop, PropSync, Component, Watch } from 'nuxt-property-decorator'
 import CircleForm from './form/CircleForm.vue'
 import CircleProductForm from './form/CircleProductForm.vue'
+import FavoriteButton from '~/components/favorites/FavoriteButton.vue'
 import {
   Circle,
   CirclePlacement,
@@ -71,6 +77,7 @@ import {
   components: {
     CircleForm,
     CircleProductForm,
+    FavoriteButton,
   },
   apollo: {
     circlePlacement: {

--- a/front/components/circle-list/CircleListForm.vue
+++ b/front/components/circle-list/CircleListForm.vue
@@ -4,11 +4,7 @@
       <v-card-title>
         <template v-if="isEditCircle">サークルリスト編集</template>
         <template v-else>
-          <favorite-button
-            v-if="circleId"
-            :circleId="circleId"
-            @update-favorite="$emit('update-favorite')"
-          />
+          <favorite-button v-if="circleId" :circleId="circleId" />
           {{ circlePlacement ? circlePlacement.formatted_placement : '' }}
           {{ circle.name }}
           <v-spacer />

--- a/front/components/circle-list/CircleListForm.vue
+++ b/front/components/circle-list/CircleListForm.vue
@@ -4,7 +4,7 @@
       <v-card-title>
         <template v-if="isEditCircle">サークルリスト編集</template>
         <template v-else>
-          <favorite-button v-if="circleId" :circleId="circleId" />
+          <favorite-button v-if="circleId" :circle-id="circleId" />
           {{ circlePlacement ? circlePlacement.formatted_placement : '' }}
           {{ circle.name }}
           <v-spacer />

--- a/front/components/circle-list/CircleListTable.vue
+++ b/front/components/circle-list/CircleListTable.vue
@@ -37,7 +37,6 @@
     <template v-slot:item.circle_name="{ item }">
       <favorite-button
         :circle-id="item.circle_id"
-        :favorite="findFavorite(item.circle_id)"
         @update-favorite="$emit('update-favorite')"
       />
       {{ item.circle_name }}
@@ -70,7 +69,7 @@ import {
   Filter,
 } from './table/filters/filterInterfaces'
 import FilterItem from './table/filters/FilterItem.vue'
-import { CircleList, Favorite } from '~/apollo/graphql'
+import { CircleList } from '~/apollo/graphql'
 import FavoriteButton from '~/components/favorites/FavoriteButton.vue'
 
 @Component({
@@ -97,12 +96,6 @@ export default class CircleListTable extends Vue {
     required: true,
   })
   private filterConditionItems!: FilterConditionItems
-
-  @Prop({
-    type: Array as PropType<Favorite[]>,
-    required: true,
-  })
-  favorites!: Favorite[]
 
   private isShowFilter: boolean = false
 
@@ -149,14 +142,6 @@ export default class CircleListTable extends Vue {
       ...this.filterConditions,
       [filter.getKey()]: e,
     }
-  }
-
-  private findFavorite(circleId: string): Favorite | null {
-    return (
-      this.favorites.find(
-        (favorite: Favorite) => favorite.circle_id === circleId
-      ) || null
-    )
   }
 
   public created() {

--- a/front/components/circle-list/CircleListTable.vue
+++ b/front/components/circle-list/CircleListTable.vue
@@ -35,10 +35,7 @@
       </v-expand-transition>
     </template>
     <template v-slot:item.circle_name="{ item }">
-      <favorite-button
-        :circle-id="item.circle_id"
-        @update-favorite="$emit('update-favorite')"
-      />
+      <favorite-button :circle-id="item.circle_id" />
       {{ item.circle_name }}
     </template>
     <template v-slot:item.circle_product_price="{ item }">

--- a/front/components/favorites/FavoriteButton.vue
+++ b/front/components/favorites/FavoriteButton.vue
@@ -6,28 +6,27 @@
 
 <script lang="ts">
 import { Vue, Component, Prop } from 'nuxt-property-decorator'
-import { PropType } from 'vue'
 import {
   Favorite,
   CreateFavoriteMutation,
   DeleteFavoriteMutation,
 } from '~/apollo/graphql'
-import { userStore } from '~/store'
+import { userStore, favoriteStore } from '~/store'
 
+/**
+ * note: このコンポーネントはfavoriteStore（vuex）のmyFavoritesが設定されている前提で使用する必要がある
+ */
 @Component({ inheritAttrs: false })
 export default class FavoriteButton extends Vue {
-  // note: propでの受け渡しをしているが、お気に入りはログイン中のユーザのものしか取り扱わないデータのため
-  //       vuexへの移行を検討している
-  @Prop({
-    type: Object as PropType<Favorite>,
-  })
-  private favorite!: Favorite | null
-
   @Prop({
     type: String,
     required: true,
   })
   private circleId!: string
+
+  private get favorite(): Favorite | null {
+    return favoriteStore.findMyFavorite(this.circleId)
+  }
 
   private get userId(): string {
     return userStore.loginUserOrEmptyUser.id

--- a/front/components/favorites/FavoriteButton.vue
+++ b/front/components/favorites/FavoriteButton.vue
@@ -42,10 +42,7 @@ export default class FavoriteButton extends Vue {
 
   private async toggleFavorite() {
     try {
-      const result = await (this.isFavorite
-        ? this.deleteFavorite()
-        : this.createFavorite())
-
+      await (this.isFavorite ? this.deleteFavorite() : this.createFavorite())
       await favoriteStore.fetchMyFavorites()
     } catch (e) {
       this.$toast.error('更新に失敗しました')

--- a/front/components/favorites/FavoriteButton.vue
+++ b/front/components/favorites/FavoriteButton.vue
@@ -40,18 +40,16 @@ export default class FavoriteButton extends Vue {
     return this.isFavorite ? 'mdi-star' : 'mdi-star-outline'
   }
 
-  private toggleFavorite() {
-    const result = this.isFavorite
-      ? this.deleteFavorite()
-      : this.createFavorite()
+  private async toggleFavorite() {
+    try {
+      const result = await (this.isFavorite
+        ? this.deleteFavorite()
+        : this.createFavorite())
 
-    result
-      .then(() => {
-        this.$emit('update-favorite')
-      })
-      .catch(() => {
-        this.$toast.error('更新に失敗しました')
-      })
+      await favoriteStore.fetchMyFavorites()
+    } catch (e) {
+      this.$toast.error('更新に失敗しました')
+    }
   }
 
   private createFavorite(): Promise<any> {

--- a/front/nuxt.config.js
+++ b/front/nuxt.config.js
@@ -32,7 +32,10 @@ export default {
   privateRuntimeConfig: {},
 
   // Plugins to run before rendering page (https://go.nuxtjs.dev/config-plugins)
-  plugins: ['~/plugins/vee-validate', '~/plugins/apollo/inject-default-apollo-client'],
+  plugins: [
+    '~/plugins/vee-validate',
+    '~/plugins/apollo/inject-default-apollo-client',
+  ],
 
   router: {
     middleware: 'auth',

--- a/front/nuxt.config.js
+++ b/front/nuxt.config.js
@@ -32,7 +32,7 @@ export default {
   privateRuntimeConfig: {},
 
   // Plugins to run before rendering page (https://go.nuxtjs.dev/config-plugins)
-  plugins: ['~/plugins/vee-validate'],
+  plugins: ['~/plugins/vee-validate', '~/plugins/apollo/inject-default-apollo-client'],
 
   router: {
     middleware: 'auth',

--- a/front/pages/teams/_team_id/events/_event_id/circle-list.vue
+++ b/front/pages/teams/_team_id/events/_event_id/circle-list.vue
@@ -30,6 +30,7 @@
       :team-id="$route.params.team_id"
       :join-event-id="joinEvent ? joinEvent.id : null"
       :editing-circle-id="editingCircleId"
+      @update-favorite="onUpdateFavorite"
       @saved="onSavedCircle"
     />
 
@@ -42,7 +43,6 @@
       :circle-lists="circleLists"
       :table-state="circleListState"
       :filter-condition-items="circleListTableFilterConditionItems"
-      :favorites="myFavorites"
       @update-favorite="onUpdateFavorite"
       @open-circle-list-form="openCircleListForm"
     />
@@ -78,7 +78,7 @@ import { FilterConditionItems } from '~/components/circle-list/table/filters/fil
 import TableStateInterface from '~/components/circle-list/table/TableStateInterface'
 import MyCircleListTableState from '~/components/circle-list/table/MyCircleListTableState'
 import TeamCircleListTableState from '~/components/circle-list/table/TeamCircleListTableState'
-import { userStore } from '~/store'
+import { userStore, favoriteStore } from '~/store'
 
 type CircleListTab = {
   key: string
@@ -181,8 +181,10 @@ type CircleListTab = {
     },
     myFavorites: {
       query: MyFavoritesQuery,
-      update(data): Favorite[] {
-        return data.myFavorites
+      // note: resultで自前で定義することで、computed setを呼び出し、
+      //       vuexStoreへ直接書き出しを行えるようにしている
+      result(result) {
+        this.myFavorites = result?.data?.myFavorites || []
       },
     },
   },
@@ -213,8 +215,6 @@ export default class CircleListPage extends Vue {
   private editingCircleId: String | null = null
 
   private selectedCircleListTabIndex: number = 0
-
-  private myFavorites: Favorite[] = []
 
   private readonly circleListTabs: CircleListTab[] = [
     {
@@ -260,6 +260,14 @@ export default class CircleListPage extends Vue {
       wantPriorities: this.wantPriorities,
       circleProductClassifications: this.circleProductClassifications,
     }
+  }
+
+  private set myFavorites(myFavorites: Favorite[]) {
+    favoriteStore.setMyFavorites(myFavorites)
+  }
+
+  private get myFavorites(): Favorite[] {
+    return favoriteStore.myFavorites
   }
 
   private isJoin(eventDate: EventDate): boolean {

--- a/front/pages/teams/_team_id/events/_event_id/circle-list.vue
+++ b/front/pages/teams/_team_id/events/_event_id/circle-list.vue
@@ -30,7 +30,6 @@
       :team-id="$route.params.team_id"
       :join-event-id="joinEvent ? joinEvent.id : null"
       :editing-circle-id="editingCircleId"
-      @update-favorite="onUpdateFavorite"
       @saved="onSavedCircle"
     />
 
@@ -43,7 +42,6 @@
       :circle-lists="circleLists"
       :table-state="circleListState"
       :filter-condition-items="circleListTableFilterConditionItems"
-      @update-favorite="onUpdateFavorite"
       @open-circle-list-form="openCircleListForm"
     />
   </v-container>
@@ -68,8 +66,6 @@ import {
   CirclePlacementClassification,
   CircleProductClassification,
   CircleProductClassificationsQuery,
-  Favorite,
-  MyFavoritesQuery,
 } from '~/apollo/graphql'
 import JoinEventForm from '~/components/join-event/JoinEventForm.vue'
 import CircleListForm from '~/components/circle-list/CircleListForm.vue'
@@ -179,14 +175,6 @@ type CircleListTab = {
         return data.circleProductClassifications
       },
     },
-    myFavorites: {
-      query: MyFavoritesQuery,
-      // note: resultで自前で定義することで、computed setを呼び出し、
-      //       vuexStoreへ直接書き出しを行えるようにしている
-      result(result) {
-        this.myFavorites = result?.data?.myFavorites || []
-      },
-    },
   },
 })
 export default class CircleListPage extends Vue {
@@ -262,14 +250,6 @@ export default class CircleListPage extends Vue {
     }
   }
 
-  private set myFavorites(myFavorites: Favorite[]) {
-    favoriteStore.setMyFavorites(myFavorites)
-  }
-
-  private get myFavorites(): Favorite[] {
-    return favoriteStore.myFavorites
-  }
-
   private isJoin(eventDate: EventDate): boolean {
     if (!this.joinEvent || !this.joinEvent.joinEventDates) {
       return false
@@ -303,8 +283,8 @@ export default class CircleListPage extends Vue {
     this.$apollo.queries.teamCircleLists.refetch()
   }
 
-  private onUpdateFavorite(): void {
-    this.$apollo.queries.myFavorites.refetch()
+  public created(): void {
+    favoriteStore.fetchMyFavorites()
   }
 }
 </script>

--- a/front/plugins/apollo/inject-default-apollo-client.ts
+++ b/front/plugins/apollo/inject-default-apollo-client.ts
@@ -1,0 +1,12 @@
+import { Context } from '@nuxt/types'
+import { Inject } from '@nuxt/types/app'
+
+/**
+ *  vuex storeからapolloの呼び出しをできるようにするために、defaultClientをinjectしている
+ *  vuex store内では this.store.$defaultApolloClient.query(...) のように呼び出せるようになる
+ *
+ *  該当のプロパティの型はtypes/vuex.d.ts等に記述してある
+ */
+export default ({ app }: Context, inject: Inject) => {
+  inject('defaultApolloClient', app.apolloProvider!.defaultClient)
+}

--- a/front/store/favorite.ts
+++ b/front/store/favorite.ts
@@ -1,5 +1,10 @@
-import { VuexModule, VuexMutation, Module } from 'nuxt-property-decorator'
-import { Favorite } from '~/apollo/graphql'
+import {
+  VuexModule,
+  VuexMutation,
+  Module,
+  VuexAction,
+} from 'nuxt-property-decorator'
+import { Favorite, MyFavoritesQuery } from '~/apollo/graphql'
 
 @Module({
   name: 'favorite',
@@ -22,5 +27,17 @@ export default class FavoriteModule extends VuexModule {
   @VuexMutation
   public setMyFavorites(myFavorites: Favorite[]): void {
     this._myFavorites = myFavorites
+  }
+
+  @VuexAction
+  public async fetchMyFavorites() {
+    const myFavorites = await this.store.$defaultApolloClient
+      .query({
+        query: MyFavoritesQuery,
+        fetchPolicy: 'network-only',
+      })
+      .then<Favorite[]>((result) => result.data.myFavorites)
+
+    this.setMyFavorites(myFavorites)
   }
 }

--- a/front/store/favorite.ts
+++ b/front/store/favorite.ts
@@ -1,0 +1,26 @@
+import { VuexModule, VuexMutation, Module } from 'nuxt-property-decorator'
+import { Favorite } from '~/apollo/graphql'
+
+@Module({
+  name: 'favorite',
+  stateFactory: true,
+  namespaced: true,
+})
+export default class FavoriteModule extends VuexModule {
+  private _myFavorites: Favorite[] = []
+
+  public get myFavorites(): Favorite[] {
+    return this._myFavorites
+  }
+
+  public get findMyFavorite(): (circleId: string) => Favorite | null {
+    return (circleId: string) =>
+      this._myFavorites.find((favorite) => favorite.circle_id === circleId) ??
+      null
+  }
+
+  @VuexMutation
+  public setMyFavorites(myFavorites: Favorite[]): void {
+    this._myFavorites = myFavorites
+  }
+}

--- a/front/types/nuxt-property-decorator.d.ts
+++ b/front/types/nuxt-property-decorator.d.ts
@@ -1,0 +1,8 @@
+import { VuexModule } from 'nuxt-property-decorator'
+import { Store } from 'vuex'
+
+declare module 'nuxt-property-decorator' {
+  export interface VuexModule {
+    store: Store<any>
+  }
+}

--- a/front/types/vue.d.ts
+++ b/front/types/vue.d.ts
@@ -1,0 +1,9 @@
+import { Vue } from 'vue/types/vue'
+import { ApolloClient } from 'apollo-client'
+
+declare module 'vue/types/vue' {
+  export interface Vue {
+    $defaultApolloClient: ApolloClient<any>
+    tttt: any
+  }
+}

--- a/front/types/vuex.d.ts
+++ b/front/types/vuex.d.ts
@@ -1,0 +1,8 @@
+import 'vuex'
+import { ApolloClient } from 'apollo-client'
+
+declare module 'vuex' {
+  interface Store<S> {
+    $defaultApolloClient: ApolloClient<any>
+  }
+}

--- a/front/utils/store-accessor.ts
+++ b/front/utils/store-accessor.ts
@@ -2,11 +2,14 @@
 import { Store } from 'vuex'
 import { getModule } from 'vuex-module-decorators'
 import UserModule from '~/store/user'
+import FavoriteModule from '~/store/favorite'
 
 let userStore: UserModule
+let favoriteStore: FavoriteModule
 
 function initializeStores(store: Store<any>): void {
   userStore = getModule(UserModule, store)
+  favoriteStore = getModule(FavoriteModule, store)
 }
 
-export { initializeStores, userStore }
+export { initializeStores, userStore, favoriteStore }


### PR DESCRIPTION
resolve: #183 

## この PR で実装される内容
サークルリスト編集ダイアログにお気に入りボタンが実装される
お気に入りの取得queryがpageのsmart queryからvuexへ移行される
vuex store内からapolloを呼び出せるようになる

## 確認

-   [x] サークルリスト編集のお気に入りボタンが機能していること
![34d1b946-e64b-40cb-9ab8-9e7937dbc9ef](https://user-images.githubusercontent.com/8841932/167411232-87f1cd41-189d-41af-a546-ec1fad937a2f.gif)

## 備考
