### PR TITLE
#99 tokenが古かった場合のSSR時にログアウトされるようにする

### DIFF
--- a/front/middleware/auth.ts
+++ b/front/middleware/auth.ts
@@ -1,20 +1,29 @@
-import { Context } from '@nuxt/types';
+import { Context } from '@nuxt/types'
+import { MeQuery } from '~/apollo/graphql'
 
 // 未ログインでもアクセスできるルート
-const CAN_ACCESS_GUEST_ROUTE_NAMES = [
-  'login',
-  'users-create'
-];
+const CAN_ACCESS_GUEST_ROUTE_NAMES = ['login', 'users-create']
 
 const canAccessGuest = (routeName: string): boolean => {
-  return CAN_ACCESS_GUEST_ROUTE_NAMES.includes(routeName);
+  return CAN_ACCESS_GUEST_ROUTE_NAMES.includes(routeName)
 }
 
-export default ({ app, redirect, route, $config }: Context) => {
-  const isUseMock = $config.IS_USE_MOCK_SERVER;
-  const routeName = route.name ?? '';
-  const token = app.$apolloHelpers.getToken();
+export default async ({ app, redirect, route, $config }: Context) => {
+  const isUseMock = $config.IS_USE_MOCK_SERVER
+  const routeName = route.name ?? ''
+  const token = app.$apolloHelpers.getToken()
   if (!isUseMock && !canAccessGuest(routeName) && !token) {
-    return redirect('/login');
+    return redirect('/login')
   }
-};
+
+  // tokenが有効か確認し、認証が通らなかった場合はログアウトさせる
+  if (token) {
+    try {
+      await app.$defaultApolloClient.query({ query: MeQuery })
+    } catch (e: any) {
+      if (~e.message.indexOf('Unauthenticated')) {
+        app.$apolloHelpers.onLogout()
+      }
+    }
+  }
+}


### PR DESCRIPTION
resolve: #99 

## この PR で実装される内容
tokenが古かった場合にエラーになって落ちる現象が解消され、ログアウト処理が走るようになる

## 確認

-   [x] tokenが古い場合にログアウトされること
![4de411e2-0849-4761-953f-94e2e65a64f0](https://user-images.githubusercontent.com/8841932/167417283-a48eed62-f5b8-4f41-8eac-53e5d68d60e8.gif)

## 備考
クッキー系の処理の問題でログインページで2回リダイレクトされてる？
致命的ではないので、一旦この状態で置いておく