### PR TITLE
#42 チームの所属メンバーを確認できる画面を実装

### DIFF
--- a/front/apollo/mutations/excludeUserForTeam.gql
+++ b/front/apollo/mutations/excludeUserForTeam.gql
@@ -1,0 +1,5 @@
+mutation ExcludeUserForTeamMutation($userAffiliationTeamId: ID!) {
+  deleteUserAffiliationTeam(id: $userAffiliationTeamId) {
+    id
+  }
+}

--- a/front/apollo/queries/teamWithAffiliationUsers.gql
+++ b/front/apollo/queries/teamWithAffiliationUsers.gql
@@ -1,0 +1,12 @@
+query TeamWithAffiliationUsersQuery($id: ID!) {
+  team(id: $id) {
+    id
+    userAffiliationTeams {
+      id
+      user {
+        id
+        name
+      }
+    }
+  }
+}

--- a/front/pages/teams/_team_id/affiliation-users.vue
+++ b/front/pages/teams/_team_id/affiliation-users.vue
@@ -1,0 +1,102 @@
+<template>
+  <v-row>
+    <v-col>
+      <confirm-dialog v-model="isOpenConfirmDialog" @confirmed="excludeUser" />
+      <v-data-table :headers="headers" :items="items" hide-default-footer>
+        <template v-slot:item.operations="{ item }">
+          <v-btn
+            color="delete"
+            @click="confirmExcludeUser(item.userAffiliationTeamId)"
+          >
+            <v-icon left>mdi-account-remove</v-icon>
+            除名
+          </v-btn>
+        </template>
+      </v-data-table>
+    </v-col>
+  </v-row>
+</template>
+
+<script lang="ts">
+import { Vue, Component } from 'nuxt-property-decorator'
+import {
+  Team,
+  TeamWithAffiliationUsersQuery,
+  ExcludeUserForTeamMutation,
+  UserAffiliationTeam,
+} from '~/apollo/graphql'
+import { DataTableHeader } from 'vuetify/types'
+
+interface AffiliationUserDataTableItems {
+  userName: string
+  userAffiliationTeamId: string
+}
+
+@Component({
+  apollo: {
+    teamWithAffiliationUsers: {
+      query: TeamWithAffiliationUsersQuery,
+      variables() {
+        const teamId: string = this.$route.params.team_id
+        return { id: teamId }
+      },
+      update(data): Team {
+        return data.team
+      },
+    },
+  },
+})
+export default class AffiliationUsersPage extends Vue {
+  private teamWithAffiliationUsers: Team = {
+    id: '',
+    name: '',
+    code: '',
+    userAffiliationTeams: [],
+  }
+
+  private isOpenConfirmDialog: boolean = false
+
+  private operatingUserAffiliationTeamId: string | null = null
+
+  private readonly headers: DataTableHeader[] = [
+    {
+      text: '名前',
+      value: 'userName',
+    },
+    {
+      text: '操作',
+      value: 'operations',
+    },
+  ]
+
+  private get items(): AffiliationUserDataTableItems[] {
+    return this.teamWithAffiliationUsers.userAffiliationTeams.map<
+      AffiliationUserDataTableItems
+    >((userAffiliationTeam: UserAffiliationTeam) => {
+      const user = userAffiliationTeam.user
+      return {
+        userName: user.name,
+        userAffiliationTeamId: userAffiliationTeam.id,
+      }
+    })
+  }
+
+  private confirmExcludeUser(userAffiliationTeamId: string): void {
+    this.operatingUserAffiliationTeamId = userAffiliationTeamId
+    this.isOpenConfirmDialog = true
+  }
+
+  private async excludeUser() {
+    const variables = {
+      userAffiliationTeamId: this.operatingUserAffiliationTeamId,
+    }
+    await this.$apollo.mutate({
+      mutation: ExcludeUserForTeamMutation,
+      variables,
+    })
+    this.$apollo.queries.teamWithAffiliationUsers.refetch()
+    this.isOpenConfirmDialog = false
+    this.$toast.success('除名しました')
+  }
+}
+</script>

--- a/front/pages/teams/_team_id/affiliation-users.vue
+++ b/front/pages/teams/_team_id/affiliation-users.vue
@@ -19,13 +19,13 @@
 
 <script lang="ts">
 import { Vue, Component } from 'nuxt-property-decorator'
+import { DataTableHeader } from 'vuetify/types'
 import {
   Team,
   TeamWithAffiliationUsersQuery,
   ExcludeUserForTeamMutation,
   UserAffiliationTeam,
 } from '~/apollo/graphql'
-import { DataTableHeader } from 'vuetify/types'
 
 interface AffiliationUserDataTableItems {
   userName: string

--- a/front/pages/teams/_team_id/index.vue
+++ b/front/pages/teams/_team_id/index.vue
@@ -37,6 +37,14 @@
         <v-btn nuxt :to="`/teams/${team.id}/want-priorities`"> 優先度 </v-btn>
       </v-card-actions>
     </v-card>
+    <v-card class="mt-3">
+      <v-card-title>所属情報</v-card-title>
+      <v-card-actions>
+        <v-btn nuxt :to="`/teams/${team.id}/affiliation-users`">
+          所属者一覧
+        </v-btn>
+      </v-card-actions>
+    </v-card>
   </v-container>
 </template>
 
@@ -61,6 +69,7 @@ export default class TeamPage extends Vue {
     id: '',
     name: '',
     code: '',
+    userAffiliationTeams: [],
   }
 }
 </script>

--- a/front/pages/teams/_team_id/join.vue
+++ b/front/pages/teams/_team_id/join.vue
@@ -29,6 +29,7 @@ export default class JoinPage extends Vue {
     id: '',
     name: '',
     code: '',
+    userAffiliationTeams: [],
   }
 
   private join(): void {

--- a/front/test/factory/TeamFactory.ts
+++ b/front/test/factory/TeamFactory.ts
@@ -7,6 +7,7 @@ export default class TeamFactory extends Factory<Team> {
       id: this.faker.random.uuid(),
       code: this.faker.random.words(10),
       name: this.faker.name.title(),
+      userAffiliationTeams: [],
     }
   }
 }

--- a/front/test/pages/mypage/index.spec.ts
+++ b/front/test/pages/mypage/index.spec.ts
@@ -17,6 +17,7 @@ describe('my page index', () => {
       {
         id: '',
         team: team,
+        user,
       },
     ]
 

--- a/laravel/app/Models/Team.php
+++ b/laravel/app/Models/Team.php
@@ -33,7 +33,7 @@ class Team extends Model
         return $this->hasMany(WantPriority::class);
     }
 
-    public function affiliateUsers(): HasMany
+    public function UserAffiliationTeams(): HasMany
     {
         return $this->hasMany(UserAffiliationTeam::class);
     }

--- a/laravel/app/Models/Team.php
+++ b/laravel/app/Models/Team.php
@@ -33,7 +33,7 @@ class Team extends Model
         return $this->hasMany(WantPriority::class);
     }
 
-    public function UserAffiliationTeams(): HasMany
+    public function userAffiliationTeams(): HasMany
     {
         return $this->hasMany(UserAffiliationTeam::class);
     }

--- a/laravel/graphql/team.graphql
+++ b/laravel/graphql/team.graphql
@@ -3,6 +3,7 @@ type Team {
     name: String!
     code: String!
     underwayEvents: [Event] @belongsToMany
+    userAffiliationTeams: [UserAffiliationTeam!]! @hasMany
     created_at: DateTime
     updated_at: DateTime
 }

--- a/laravel/graphql/userAffiliationTeam.graphql
+++ b/laravel/graphql/userAffiliationTeam.graphql
@@ -1,10 +1,11 @@
 type UserAffiliationTeam {
     id: ID!
-    user: User @belongsTo
-    team: Team @belongsTo
+    user: User! @belongsTo
+    team: Team! @belongsTo
 }
 
 extend type Mutation @guard {
     joinTeam(team_id: ID!): UserAffiliationTeam
         @field(resolver: "App\\GraphQL\\Mutations\\JoinTeam")
+    deleteUserAffiliationTeam(id: ID!): UserAffiliationTeam @delete
 }


### PR DESCRIPTION
resolve: #42 

## この PR で実装される内容
チームの所属メンバーを確認できる画面が実装される

## 確認

-   [x] 一覧が表示でき、除名できること
![4e6b0975-deb2-44b3-a4c1-453c3f05ece9](https://user-images.githubusercontent.com/8841932/168592522-53f5cc21-786c-4858-b35b-7efce4175631.gif)

## 備考
#197 にて confirmDialog周りはリファクタ