### PR TITLE
#197　confirmDialogをPromiseで扱えるようにする

### DIFF
--- a/front/components/dialog/ConfirmDialog.vue
+++ b/front/components/dialog/ConfirmDialog.vue
@@ -6,7 +6,7 @@
     v-on="listeners"
   >
     <v-card>
-      <v-card-title class="headline">削除します。よろしいですか？</v-card-title>
+      <v-card-title class="headline"> {{ message }} </v-card-title>
       <v-card-actions>
         <v-spacer></v-spacer>
         <v-btn @click="onCanceled">キャンセル</v-btn>
@@ -19,24 +19,23 @@
 
 <script lang="ts">
 import { Vue, Prop, Component } from 'nuxt-property-decorator'
+import {
+  confirmDialogContainer,
+  ConfirmPromiseFn,
+} from './ConfirmDialog/ConfirmDialogContainer'
 
 @Component({
   inheritAttrs: false,
 })
 export default class ConfirmDialog extends Vue {
-  @Prop({ type: Boolean, required: true })
-  private value!: Boolean
-
   @Prop({ type: String, default: '500px' })
   private maxWidth!: String
 
-  private get isOpen(): Boolean {
-    return this.value
-  }
+  private resolve: ConfirmPromiseFn | null = null
 
-  private set isOpen(isOpen: Boolean) {
-    this.$emit('input', isOpen)
-  }
+  private isOpen: boolean = false
+
+  private customMessage: string | null = null
 
   private get listeners() {
     return {
@@ -45,12 +44,38 @@ export default class ConfirmDialog extends Vue {
     }
   }
 
-  private onCanceled() {
-    this.isOpen = false
+  private get message(): string {
+    return this.customMessage ?? '削除します。よろしいですか？'
+  }
+
+  private onCanceled(): void {
+    if (!this.resolve) {
+      return
+    }
+    this.resolve(false)
+    this.close()
   }
 
   private onConfirmed() {
-    this.$emit('confirmed')
+    if (!this.resolve) {
+      return
+    }
+    this.resolve(true)
+    this.close()
+  }
+
+  private close() {
+    this.isOpen = false
+  }
+
+  private promiseListener(resolve: ConfirmPromiseFn, message?: string) {
+    this.resolve = resolve
+    this.customMessage = message ?? null
+    this.isOpen = true
+  }
+
+  public created() {
+    confirmDialogContainer.listen(this.promiseListener)
   }
 }
 </script>

--- a/front/components/dialog/ConfirmDialog/ConfirmDialogContainer.ts
+++ b/front/components/dialog/ConfirmDialog/ConfirmDialogContainer.ts
@@ -1,0 +1,41 @@
+export type ConfirmPromiseFn = (value: boolean) => void
+type PromiseListener = (resolve: ConfirmPromiseFn, message?: string) => void
+
+export interface ConfirmDialogInterface {
+  confirm(message?: string): Promise<boolean>
+}
+
+class ConfirmDialogContainer implements ConfirmDialogInterface {
+  static instance: ConfirmDialogContainer
+  private promise: Promise<any> | null = null
+  private listener?: PromiseListener
+
+  private constructor() {
+    ConfirmDialogContainer.instance = this
+  }
+
+  public static getInstance(): ConfirmDialogContainer {
+    if (!ConfirmDialogContainer.instance) {
+      new ConfirmDialogContainer()
+    }
+
+    return ConfirmDialogContainer.instance
+  }
+
+  public listen(listener: PromiseListener) {
+    this.listener = listener
+  }
+
+  public confirm(message?: string): Promise<boolean> {
+    this.promise = new Promise<boolean>((resolve) => {
+      if (!this.listener) {
+        return
+      }
+      this.listener(resolve, message)
+    })
+
+    return this.promise
+  }
+}
+
+export const confirmDialogContainer = ConfirmDialogContainer.getInstance()

--- a/front/components/masters/AbstractMasterPage.vue
+++ b/front/components/masters/AbstractMasterPage.vue
@@ -8,7 +8,6 @@
         :team-id="teamId"
         @saved="refresh"
       />
-      <confirm-dialog v-model="isOpenConfirmDialog" @confirmed="remove" />
       <v-data-table
         :headers="headers"
         :items="models"
@@ -28,7 +27,7 @@
           <v-btn color="edit" @click="edit(item)"
             ><v-icon left>mdi-pencil</v-icon>編集</v-btn
           >
-          <v-btn color="delete" @click="confirmRemove(item)"
+          <v-btn color="delete" @click="remove(item)"
             ><v-icon left>mdi-delete</v-icon>削除</v-btn
           >
         </template>
@@ -59,7 +58,6 @@ export default abstract class AbstractMasterPage<
   protected models: Model[] = []
 
   private isOpenFormDialog: boolean = false
-  private isOpenConfirmDialog: boolean = false
   private selectedModel?: Model
 
   private setDefaultSelectedModel(): void {
@@ -76,23 +74,21 @@ export default abstract class AbstractMasterPage<
     this.isOpenFormDialog = true
   }
 
-  private confirmRemove(model: Model): void {
-    this.selectedModel = model
-    this.isOpenConfirmDialog = true
-  }
+  private async remove(model: Model) {
+    if (!(await this.$confirmDialog.confirm())) {
+      return
+    }
 
-  private remove(): void {
     const res = this.$apollo.mutate({
       mutation: this.deleteMutation,
       variables: {
-        id: this.selectedModel?.id,
+        id: model.id,
       },
     })
 
     res
       .then(() => {
         this.$toast.success('削除しました')
-        this.isOpenConfirmDialog = false
         this.refresh()
       })
       .catch(() => {

--- a/front/layouts/default.vue
+++ b/front/layouts/default.vue
@@ -40,6 +40,7 @@
     </v-app-bar>
     <v-main>
       <v-container fluid>
+        <confirm-dialog />
         <nuxt />
       </v-container>
     </v-main>
@@ -64,6 +65,7 @@ import {
   UnderwayEventsForJoinedTeamsQuery,
 } from '~/apollo/graphql'
 import { userStore } from '~/store'
+import ConfirmDialog from '~/components/dialog/ConfirmDialog.vue'
 
 type UnderwayCircleListItem = {
   team: Team
@@ -71,6 +73,9 @@ type UnderwayCircleListItem = {
 }
 
 @Component({
+  components: {
+    ConfirmDialog,
+  },
   apollo: {
     underwayCircleListItems: {
       query: UnderwayEventsForJoinedTeamsQuery,

--- a/front/nuxt.config.js
+++ b/front/nuxt.config.js
@@ -35,6 +35,7 @@ export default {
   plugins: [
     '~/plugins/vee-validate',
     '~/plugins/apollo/inject-default-apollo-client',
+    '~/plugins/confirm-dialog',
   ],
 
   router: {

--- a/front/pages/teams/_team_id/affiliation-users.vue
+++ b/front/pages/teams/_team_id/affiliation-users.vue
@@ -1,12 +1,11 @@
 <template>
   <v-row>
     <v-col>
-      <confirm-dialog v-model="isOpenConfirmDialog" @confirmed="excludeUser" />
       <v-data-table :headers="headers" :items="items" hide-default-footer>
         <template v-slot:item.operations="{ item }">
           <v-btn
             color="delete"
-            @click="confirmExcludeUser(item.userAffiliationTeamId)"
+            @click="excludeUser(item.userAffiliationTeamId)"
           >
             <v-icon left>mdi-account-remove</v-icon>
             除名
@@ -54,10 +53,6 @@ export default class AffiliationUsersPage extends Vue {
     userAffiliationTeams: [],
   }
 
-  private isOpenConfirmDialog: boolean = false
-
-  private operatingUserAffiliationTeamId: string | null = null
-
   private readonly headers: DataTableHeader[] = [
     {
       text: '名前',
@@ -81,21 +76,19 @@ export default class AffiliationUsersPage extends Vue {
     })
   }
 
-  private confirmExcludeUser(userAffiliationTeamId: string): void {
-    this.operatingUserAffiliationTeamId = userAffiliationTeamId
-    this.isOpenConfirmDialog = true
-  }
+  private async excludeUser(userAffiliationTeamId: string) {
+    if (!(await this.$confirmDialog.confirm('除名します。よろしいですか？'))) {
+      return
+    }
 
-  private async excludeUser() {
     const variables = {
-      userAffiliationTeamId: this.operatingUserAffiliationTeamId,
+      userAffiliationTeamId,
     }
     await this.$apollo.mutate({
       mutation: ExcludeUserForTeamMutation,
       variables,
     })
     this.$apollo.queries.teamWithAffiliationUsers.refetch()
-    this.isOpenConfirmDialog = false
     this.$toast.success('除名しました')
   }
 }

--- a/front/plugins/confirm-dialog.ts
+++ b/front/plugins/confirm-dialog.ts
@@ -1,0 +1,7 @@
+import { Context } from '@nuxt/types'
+import { Inject } from '@nuxt/types/app'
+import { confirmDialogContainer } from '~/components/dialog/ConfirmDialog/ConfirmDialogContainer'
+
+export default ({ app }: Context, inject: Inject) => {
+  inject('confirmDialog', confirmDialogContainer)
+}

--- a/front/test/pages/masterPageTest.ts
+++ b/front/test/pages/masterPageTest.ts
@@ -16,6 +16,11 @@ const makeWrapper = (
     })
   })
   const refetch = jest.fn()
+  const confirm = jest.fn((value) => {
+    return new Promise((resolve) => {
+      resolve(true)
+    })
+  })
   const wrapper = mount(pageComponent, {
     mocks: {
       $route: {
@@ -34,6 +39,9 @@ const makeWrapper = (
       $toast: {
         success: jest.fn(),
         error: jest.fn(),
+      },
+      $confirmDialog: {
+        confirm,
       },
     },
     stubs: {
@@ -94,13 +102,7 @@ export const testMasterPage = (
     await flushPromises()
 
     const vm: any = wrapper.vm as any
-    expect(wrapper.findAll('.v-dialog').length).toBe(0)
-
-    vm.confirmRemove(model)
-    await flushPromises()
-    expect(wrapper.findAll('.v-dialog').length).toBe(1)
-
-    vm.remove()
+    vm.remove(model)
     await flushPromises()
     expect(mutate).toBeCalled()
     expect(mutate.mock.calls[0][0].variables.id).toBe(model.id)

--- a/front/types/vue.d.ts
+++ b/front/types/vue.d.ts
@@ -1,9 +1,10 @@
 import { Vue } from 'vue/types/vue'
 import { ApolloClient } from 'apollo-client'
+import { ConfirmDialogInterface } from '~/components/dialog/ConfirmDialog/ConfirmDialogContainer'
 
 declare module 'vue/types/vue' {
   export interface Vue {
     $defaultApolloClient: ApolloClient<any>
-    tttt: any
+    $confirmDialog: ConfirmDialogInterface
   }
 }

--- a/front/types/vuex.d.ts
+++ b/front/types/vuex.d.ts
@@ -1,8 +1,10 @@
 import 'vuex'
 import { ApolloClient } from 'apollo-client'
+import { ConfirmDialogInterface } from '~/components/dialog/ConfirmDialog/ConfirmDialogContainer'
 
 declare module 'vuex' {
   interface Store<S> {
     $defaultApolloClient: ApolloClient<any>
+    $confirmDialog: ConfirmDialogInterface
   }
 }


### PR DESCRIPTION
resolve: #197

## この PR で実装される内容
confirmDialogをPromiseで扱えるようになる

## 確認

-   [x] キャンセル時は実行されないこと
-   [x] 実行時は実行されること
![3c3a35ce-d02f-4d8b-91d0-b39e5c88cfd8](https://user-images.githubusercontent.com/8841932/168608627-b7badb05-135c-46be-8fdc-66358cb6d9c7.gif)


## 備考
