### PR TITLE
#204 iOSで正規表現エラーになる不具合の修正

### DIFF
--- a/front/plugins/apollo/csrf-link.ts
+++ b/front/plugins/apollo/csrf-link.ts
@@ -4,7 +4,8 @@ const findCsrfTokenInCookie = (): string | null => {
   const [_, token] = document.cookie
     .split(';')
     .map((value: string) => {
-      return value.split(/(?<=^[^=]+?)=/)
+      const [key, ...values] = value.split('=')
+      return [key, values.join('=')]
     })
     .find(([key, _]) => {
       return key === 'XSRF-TOKEN'


### PR DESCRIPTION
resolve: #204 

## この PR で実装される内容
否定先読みの正規表現をやめ、iOSでアプリにアクセスできるようになる

## 備考
