### PR TITLE
#195 csrf tokenが古かった場合、ログイン画面に飛ばす

### DIFF
--- a/front/plugins/apollo/error-handler.ts
+++ b/front/plugins/apollo/error-handler.ts
@@ -4,7 +4,7 @@ import { onError } from 'apollo-link-error'
 import { userStore } from '~/store'
 
 export default (context: Context) => {
-  return onError(({ graphQLErrors }) => {
+  return onError(({ graphQLErrors, networkError }) => {
     if (graphQLErrors) {
       graphQLErrors.forEach(async (graphQLError: GraphQLError) => {
         const category: string = graphQLError?.extensions?.category ?? ''
@@ -17,6 +17,12 @@ export default (context: Context) => {
           await context.redirect('/login')
         }
       })
+    }
+    if (networkError) {
+      const message: string = (networkError as any)?.result?.message || ''
+      if (message === 'The payload is invalid.') {
+        context.redirect('/login')
+      }
     }
   })
 }


### PR DESCRIPTION
resolve: #195 

## この PR で実装される内容
不正なcsrf tokenだった場合、ログイン画面に遷移するようになる

## 確認

-   [ ] CSRF tokenが不正な場合、ログイン画面へリダイレクトされること
![image](https://user-images.githubusercontent.com/8841932/170071914-252d5b93-578c-49e2-9d3e-417122e84554.png)
![3ab00cb8-084a-4225-a793-a58aff87dc93](https://user-images.githubusercontent.com/8841932/170072154-8c85bae4-4f8f-4e88-a1cc-9796104dbe37.gif)


## 備考
