### PR TITLE
#211 ログアウト時にapolloのキャッシュを飛ばす

### DIFF
--- a/front/layouts/default.vue
+++ b/front/layouts/default.vue
@@ -119,6 +119,7 @@ export default class DefaultLayout extends Vue {
       })
       .then(() => {
         this.user = null
+        this.$defaultApolloClient.resetStore()
         this.$toast.success('ログアウトしました。')
         this.$router.push('/login')
       })


### PR DESCRIPTION
resolve: #211 

## この PR で実装される内容
ログアウト時にapolloのキャッシュがリセットされるようになり、ログインしなおしたユーザの情報が表示されるようになる

## 確認

-   [x] ユーザ情報が更新されること
![df92fc2f-ce56-4c52-baf5-33b1700fd44b](https://user-images.githubusercontent.com/8841932/170307311-c8d73690-f8f9-475b-bc73-8792e2eb67d2.gif)


## 備考
