### PR TITLE
#216 circle ciのexecutorを更新

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,7 +61,7 @@ commands:
 executors:
   test-executer:
     machine:
-      image: circleci/classic:edge
+      image: ubuntu-2204:2022.04.1
 
 jobs:
   test:


### PR DESCRIPTION
resolve: #217

## この PR で実装される内容
cicrcle ciのexecutorが更新される

## 確認

-   [x] CIが通り、使用不可になる警告文がなくなっていること
![image](https://user-images.githubusercontent.com/8841932/170979189-4cba6437-dd1a-4779-a5c0-dbd0b3a79fa1.png)
![image](https://user-images.githubusercontent.com/8841932/170979252-be35ad2e-b939-49be-af1f-92c9abdbbea8.png)


## 備考
