### PR TITLE
#41 チームの進行中のイベントを持てるようにする

### DIFF
--- a/front/apollo/queries/finishedEventsForJoinedTeams.gql
+++ b/front/apollo/queries/finishedEventsForJoinedTeams.gql
@@ -1,11 +1,11 @@
-query UnderwayEventsForJoinedTeamsQuery($id: ID!) {
+query FinishedEventsForJoinedTeamsQuery($id: ID!) {
   user(id: $id) {
     id
     affiliateTeams {
       team {
         id
         name
-        underwayEvents {
+        finishedEvents {
           id
           name
         }

--- a/laravel/app/Console/Commands/UpdateEventIsProgress.php
+++ b/laravel/app/Console/Commands/UpdateEventIsProgress.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\EventDate;
+use Illuminate\Console\Command;
+use Illuminate\Database\Eloquent\Collection;
+
+class UpdateEventIsProgress extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'update:event:is-progress {--all}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'update to is progress column in events table';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return int
+     */
+    public function handle()
+    {
+        $this->fetchTargetEvents()->each(fn ($event) => $event->updateIsProgress());
+
+        return 0;
+    }
+
+    private function fetchTargetEvents(): Collection
+    {
+        return EventDate::with('event')
+            ->when(
+                !$this->option('all'),
+                fn ($builder) => $builder->whereBetween('date', [now()->subDay(), now()->addDay()])
+            )
+            ->get()
+            ->unique('event_id')
+            ->map(fn ($eventDate) => $eventDate->event);
+    }
+}

--- a/laravel/app/Console/Kernel.php
+++ b/laravel/app/Console/Kernel.php
@@ -20,6 +20,7 @@ class Kernel extends ConsoleKernel
         \App\Console\Commands\Make\MakeMutationCommand::class,
         \App\Console\Commands\Make\MakeModelWithInputCommand::class,
         \App\Console\Commands\Make\MakeGraphqlDefinitionCommand::class,
+        \App\Console\Commands\UpdateEventIsProgress::class,
     ];
 
     /**

--- a/laravel/app/Models/Event.php
+++ b/laravel/app/Models/Event.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 
@@ -11,6 +12,10 @@ class Event extends Model
 
     protected $fillable = ['name'];
 
+    protected $casts = [
+        'is_progress' => 'boolean',
+    ];
+
     public function eventDates(): HasMany
     {
         return $this->hasMany(EventDate::class);
@@ -19,5 +24,31 @@ class Event extends Model
     public function eventAffiliationTeams(): HasMany
     {
         return $this->hasMany(EventAffiliationTeam::class);
+    }
+
+    public function scopeFilterUnderwayEvents(Builder $builder): Builder
+    {
+        return $builder->where('is_progress', true);
+    }
+
+    public function scopeFilterFinishedEvents(Builder $builder): Builder
+    {
+        return $builder->where('is_progress', false);
+    }
+
+    public function updateIsProgress(): void
+    {
+        $this->is_progress = $this->judgeIsProgress();
+        $this->save();
+    }
+
+    private function judgeIsProgress(): bool
+    {
+        $latestDate = optional($this->eventDates()->latest('date')->first())->date;
+        if (is_null($latestDate)) {
+            return false;
+        }
+
+        return now()->setTime(0, 0)->lessThanOrEqualTo($latestDate);
     }
 }

--- a/laravel/app/Models/EventDate.php
+++ b/laravel/app/Models/EventDate.php
@@ -11,6 +11,8 @@ class EventDate extends Model
 
     protected $fillable = ['name', 'date', 'is_production_day'];
 
+    protected $dates = ['date'];
+
     public function event(): BelongsTo
     {
         return $this->belongsTo(Event::class);

--- a/laravel/app/Models/Team.php
+++ b/laravel/app/Models/Team.php
@@ -45,6 +45,11 @@ class Team extends Model
 
     public function underwayEvents(): BelongsToMany
     {
-        return $this->belongsToMany(Event::class, 'event_affiliation_teams');
+        return $this->belongsToMany(Event::class, 'event_affiliation_teams')->filterUnderwayEvents();
+    }
+
+    public function finishedEvents(): BelongsToMany
+    {
+        return $this->belongsToMany(Event::class, 'event_affiliation_teams')->filterFinishedEvents();
     }
 }

--- a/laravel/app/Observers/EventDateObserver.php
+++ b/laravel/app/Observers/EventDateObserver.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Observers;
+
+use App\Models\EventDate;
+
+class EventDateObserver
+{
+    public function saved(EventDate $eventDate)
+    {
+        $eventDate->event->updateIsProgress();
+    }
+}

--- a/laravel/app/Providers/EventServiceProvider.php
+++ b/laravel/app/Providers/EventServiceProvider.php
@@ -5,9 +5,10 @@ namespace App\Providers;
 use Illuminate\Auth\Events\Registered;
 use Illuminate\Auth\Listeners\SendEmailVerificationNotification;
 use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvider;
-use Illuminate\Support\Facades\Event;
 
+use App\Models\EventDate;
 use App\Models\Team;
+use App\Observers\EventDateObserver;
 use App\Observers\TeamObserver;
 
 class EventServiceProvider extends ServiceProvider
@@ -31,5 +32,6 @@ class EventServiceProvider extends ServiceProvider
     public function boot()
     {
         Team::observe(TeamObserver::class);
+        EventDate::observe(EventDateObserver::class);
     }
 }

--- a/laravel/database/datasetFactories/EventDatasetFactory.php
+++ b/laravel/database/datasetFactories/EventDatasetFactory.php
@@ -17,13 +17,14 @@ class EventDatasetFactory
         $teamDataset = (new TeamDatasetFactory())->create();
         $user = $teamDataset['user'];
         $team = $teamDataset['team'];
+
         $event = Event::factory()->has(
             EventDate::factory()
                 ->count(3)
                 ->sequence(
-                    ['name' => '1日目'],
-                    ['name' => '2日目'],
-                    ['name' => '3日目']
+                    ['name' => '1日目', 'date' => now()->addMonth()],
+                    ['name' => '2日目',  'date' => now()->addMonth()->addDay()],
+                    ['name' => '3日目',  'date' => now()->addMonth()->addDay(2)]
                 )
                 ->state(['is_production_day' => true])
         )->create();

--- a/laravel/database/factories/EventFactory.php
+++ b/laravel/database/factories/EventFactory.php
@@ -23,6 +23,7 @@ class EventFactory extends Factory
     {
         return [
             'name' => $this->faker->word,
+            'is_progress' => true,
         ];
     }
 }

--- a/laravel/database/migrations/2022_05_30_111840_add_is_progress_column_events_table.php
+++ b/laravel/database/migrations/2022_05_30_111840_add_is_progress_column_events_table.php
@@ -14,7 +14,7 @@ class AddIsProgressColumnEventsTable extends Migration
     public function up()
     {
         Schema::table('events', function (Blueprint $table) {
-            $table->boolean('is_progress')->after('name');
+            $table->boolean('is_progress')->after('name')->default(true);
         });
     }
 

--- a/laravel/database/migrations/2022_05_30_111840_add_is_progress_column_events_table.php
+++ b/laravel/database/migrations/2022_05_30_111840_add_is_progress_column_events_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddIsProgressColumnEventsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('events', function (Blueprint $table) {
+            $table->boolean('is_progress')->after('name');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('events', function (Blueprint $table) {
+            $table->dropColumn('is_progress');
+        });
+    }
+}

--- a/laravel/graphql/team.graphql
+++ b/laravel/graphql/team.graphql
@@ -3,6 +3,7 @@ type Team {
     name: String!
     code: String!
     underwayEvents: [Event] @belongsToMany
+    finishedEvents: [Event] @belongsToMany
     userAffiliationTeams: [UserAffiliationTeam!]! @hasMany
     created_at: DateTime
     updated_at: DateTime

--- a/laravel/tests/Feature/Models/EventDateTest.php
+++ b/laravel/tests/Feature/Models/EventDateTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Tests\Feature\Models;
+
+use Illuminate\Foundation\Testing\WithFaker;
+
+use App\Models\Event;
+use App\Models\EventDate;
+use Tests\TestCase;
+
+class EventDateTest extends TestCase
+{
+    use WithFaker;
+
+    public function testOnSavedObserver()
+    {
+        $event = Event::factory()->hasEventDates(3)->create([
+            'is_progress' => false,
+        ]);
+        $latestEventDate = $event->eventDates()->latest('date')->first();
+
+        $this->travelTo($latestEventDate->date->copy()->addDay());
+        EventDate::factory()->create([
+            'event_id' => $event->id,
+            'date' => $latestEventDate->date,
+        ]);
+        $event->refresh();
+        $this->assertFalse($event->is_progress);
+
+        $this->travelTo($latestEventDate->date->copy()->addDay());
+        EventDate::factory()->create([
+            'event_id' => $event->id,
+            'date' => $latestEventDate->date->copy()->addDay(),
+        ]);
+        $event->refresh();
+        $this->assertTrue($event->is_progress);
+    }
+}

--- a/laravel/tests/Feature/Models/EventTest.php
+++ b/laravel/tests/Feature/Models/EventTest.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Tests\Feature\Models;
+
+use ReflectionClass;
+
+use Illuminate\Foundation\Testing\WithFaker;
+
+use App\Models\Event;
+use Tests\TestCase;
+
+class EventTest extends TestCase
+{
+    use WithFaker;
+
+    public function testJudgeIsProgress()
+    {
+        $event = Event::factory()->hasEventDates(3)->create();
+        $latestEventDate = $event->eventDates()->latest('date')->first();
+
+        $reflectionClass = new ReflectionClass($event);
+        $reflectionMethod = $reflectionClass->getMethod('judgeIsProgress');
+        $reflectionMethod->setAccessible(true);
+
+        // 同日
+        $this->travelTo($latestEventDate->date);
+        $this->assertTrue($reflectionMethod->invoke($event));
+
+        // 同日の昼間などはまだ同じ日として扱う
+        $this->travelTo($latestEventDate->date->copy()->addMinute(12));
+        $this->assertTrue($reflectionMethod->invoke($event));
+
+        // 1日後
+        $this->travelTo($latestEventDate->date->copy()->addDay());
+        $this->assertFalse($reflectionMethod->invoke($event));
+    }
+
+    public function testUpdateIsProgress()
+    {
+        $event = Event::factory()->hasEventDates(3)->create([
+            'is_progress' => false,
+        ]);
+        $latestEventDate = $event->eventDates()->latest('date')->first();
+
+        $this->travelTo($latestEventDate->date);
+        $event->updateIsProgress();
+        $event->refresh();
+        $this->assertTrue($event->is_progress);
+
+        $this->travelTo($latestEventDate->date->copy()->addDay());
+        $event->updateIsProgress();
+        $event->refresh();
+        $this->assertFalse($event->is_progress);
+    }
+
+    public function testScopeFilterUnderwayEvents()
+    {
+        $underwayEvent = Event::factory()->create([
+            'is_progress' => true,
+        ]);
+        $finishedEvent = Event::factory()->create([
+            'is_progress' => false,
+        ]);
+
+        $eventIds = Event::filterUnderwayEvents()->pluck('id');
+        $this->assertContains($underwayEvent->id, $eventIds);
+        $this->assertNotContains($finishedEvent->id, $eventIds);
+    }
+
+    public function testScopeFilterFinishedEvents()
+    {
+        $underwayEvent = Event::factory()->create([
+            'is_progress' => true,
+        ]);
+        $finishedEvent = Event::factory()->create([
+            'is_progress' => false,
+        ]);
+
+        $eventIds = Event::filterFinishedEvents()->pluck('id');
+        $this->assertNotContains($underwayEvent->id, $eventIds);
+        $this->assertContains($finishedEvent->id, $eventIds);
+    }
+}


### PR DESCRIPTION
resolve: #41 

## この PR で実装される内容
イベントが進行中か終了したものかを判別する機能が実装される
　- eventに紐づくeventDateの一番最後の日付が昨日以前の場合は終了済みとみなす
　- 日次バッチでフラグのカラムは更新する予定
　　- コマンドの実装まではしてある（スケジュール登録はまだ）

## 確認

-   [x] 終了しているものは終了済みイベントに表示されること
-   [x] 進行中のものは進行中イベントに表示されること
-   [x] イベント作成時に紐づく日付に応じて `events.is_progress` が更新されること
![b7617373-c4d2-4dc0-ab71-804ae167f4bb](https://user-images.githubusercontent.com/8841932/171146027-9417ebb8-e1c2-4d43-aab3-287022865b5e.gif)

## 備考
