### PR TITLE
#221 参加情報の更新ができない不具合の修正

### DIFF
--- a/front/components/circle-list/form/CircleForm.vue
+++ b/front/components/circle-list/form/CircleForm.vue
@@ -1,5 +1,5 @@
 <template>
-  <validation-observer ref="validationObserver" tag="v-form">
+  <validation-observer ref="validationObserver" tag="form">
     <v-container>
       <v-row dense>
         <v-col cols="12">

--- a/front/components/circle-list/form/CircleProductForm.vue
+++ b/front/components/circle-list/form/CircleProductForm.vue
@@ -1,5 +1,5 @@
 <template>
-  <validation-observer ref="validationObserver" tag="v-form">
+  <validation-observer ref="validationObserver" tag="form">
     <v-container>
       <v-row dense>
         <v-col cols="12">

--- a/front/components/events/EventForm.vue
+++ b/front/components/events/EventForm.vue
@@ -1,5 +1,5 @@
 <template>
-  <validation-observer ref="validationObserver" tag="v-form">
+  <validation-observer ref="validationObserver" tag="form">
     <v-container>
       <v-row dense>
         <v-col cols="12">

--- a/front/components/join-event/JoinEventForm.vue
+++ b/front/components/join-event/JoinEventForm.vue
@@ -5,7 +5,7 @@
       <v-card-text>
         <validation-observer
           ref="validationObserver"
-          tag="v-form"
+          tag="form"
           @submit.prevent="submit"
         >
           <v-container>

--- a/front/components/masters/AbstractMasterForm.vue
+++ b/front/components/masters/AbstractMasterForm.vue
@@ -5,7 +5,7 @@
       <v-card-text>
         <validation-observer
           ref="validationObserver"
-          tag="v-form"
+          tag="form"
           @submit.prevent="submit"
         >
           <v-container>

--- a/front/components/teams/TeamForm.vue
+++ b/front/components/teams/TeamForm.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-form>
+  <form>
     <v-container>
       <v-row dense>
         <v-col cols="12">
@@ -10,7 +10,7 @@
         </v-col>
       </v-row>
     </v-container>
-  </v-form>
+  </form>
 </template>
 
 <script lang="ts">

--- a/front/components/users/UserForm.vue
+++ b/front/components/users/UserForm.vue
@@ -1,5 +1,5 @@
 <template>
-  <validation-observer ref="validationObserver" tag="v-form">
+  <validation-observer ref="validationObserver" tag="form">
     <v-container>
       <v-row dense>
         <v-col cols="12">

--- a/front/pages/login.vue
+++ b/front/pages/login.vue
@@ -1,5 +1,5 @@
 <template>
-  <validation-observer ref="validationObserver" tag="v-form">
+  <validation-observer ref="validationObserver" tag="form">
     <v-container>
       <v-row dense>
         <v-col cols="12">


### PR DESCRIPTION
resolve: #221 

## この PR で実装される内容
npm run build -> npm run strat 時に参加情報、マスタ系の更新ができない不具合が解消される
v-formをタグとして出力していたため、formと認識されていなかったらしい。

※ 多分devだと解釈できるjsが残ってて動作してた系？

## 確認

-   [x] `npm run start` 時に参加情報が編集できること
![d4a24734-27c9-48f0-b072-f7e87399ea5e](https://user-images.githubusercontent.com/8841932/171827876-1b372810-859e-4abc-a629-90effc3cb508.gif)

## 備考
