### PR TITLE
#240 認証が切れているときに一瞬エラー画面が表示される不具合を修正

### DIFF
--- a/front/middleware/auth.ts
+++ b/front/middleware/auth.ts
@@ -14,6 +14,7 @@ export default async ({
   route,
   $config,
   $axios,
+  redirect,
 }: Context & { $axios: any }) => {
   // csrf tokenの更新を行う
   // note: csrf tokenはcookieに書き込まれる（ブラウザで処理される）ため、レスポンスの処理はせずにリクエストするだけでOK
@@ -22,10 +23,14 @@ export default async ({
   const isUseMock = $config.IS_USE_MOCK_SERVER
   const routeName = route.name ?? ''
   if (!isUseMock && !canAccessGuest(routeName)) {
-    // note: ログインできていない場合、ここからapolloErrorLinkのUnauthenticatedのログアウト / リダイレクト処理が走る
-    const user = await app.$defaultApolloClient
-      .query({ query: MeQuery, fetchPolicy: 'no-cache' })
-      .then((result: any) => result.data.me)
-    userStore.setLoginUser(user)
+    try {
+      const user = await app.$defaultApolloClient
+        .query({ query: MeQuery, fetchPolicy: 'no-cache' })
+        .then((result: any) => result.data.me)
+      userStore.setLoginUser(user)
+    } catch (e) {
+      // note: 明示的にredirect関数を呼び出し、返さないと一瞬遷移先のページが表示されてしまうので、これは必要
+      return redirect('/login')
+    }
   }
 }


### PR DESCRIPTION
resolve: #240 

## この PR で実装される内容
認証が切れているときに一瞬エラー画面が表示された後リダイレクトされていたのが、エラー画面表示なしでリダイレクトされるようになる

## 確認

-   [x] エラー画面が表示されずにリダイレクトされること
![fb64c50a-162d-43c4-b9eb-07a2ea793fea](https://user-images.githubusercontent.com/8841932/172818985-06f4cbba-b52c-4cb3-a6a0-b22189302c2b.gif)

## 備考
