### PR TITLE
#89 frontコンテナのコンテナ内での生成物の共有を緩くして、パフォーマンスをよくする

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,6 +68,13 @@ jobs:
     executor: test-executer
     steps:
       - checkout
+      - run:
+          name: make front build directories
+          command: |
+            mkdir -m 777 ./front/node_modules
+            mkdir -m 777 ./front/.nuxt
+            mkdir -m 777 ./front/coverage
+            mkdir -m 777 ./front/dist
       - load-docker-images
       - run: docker-compose up -d --build
       - run:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,6 +43,13 @@ services:
         build: ./docker/front
         volumes:
             - ./front:/usr/src/app
+
+            # note: container内で書き込みをよく行うディレクトリはマウントの同期を弱くすることでnpmの各種コマンドのパフォーマンスを改善している
+            # docs: https://docs.docker.jp/docker-for-mac/osxfs-caching.html
+            - ./front/.nuxt:/usr/src/app/.nuxt:delegated
+            - ./front/dist:/usr/src/app/dist:delegated
+            - ./front/node_modules:/usr/src/app/node_modules:delegated
+            - ./front/coverage:/usr/src/app/coverage:delegated
         tty: true
         ports:
             - 3000:3000


### PR DESCRIPTION
resolve: #89 

## この PR で実装される内容
frontコンテナ内の書き込みが多く、コンテナ内で生成される共有物のマウントをdelegatedにし、 `npm run dev` などのコマンドが高速化される

## 確認

-   [x] コマンドが動作し、高速化されていること
変更前
![image](https://user-images.githubusercontent.com/8841932/172821993-335f3b56-17b3-4f73-99bc-cf2f945f641b.png)
変更後
![image](https://user-images.githubusercontent.com/8841932/172822040-f04decc1-c900-43bd-8fcf-6bae0d8a9f1f.png)


## 備考
