### PR TITLE
#247 イベント登録時にヘッダーが更新されない不具合の解消

### DIFF
--- a/front/pages/teams/_team_id/events/create.vue
+++ b/front/pages/teams/_team_id/events/create.vue
@@ -42,7 +42,12 @@ export default class CreateEvent extends Vue {
       variables: {
         input: this.event,
       },
+      refetchQueries: [
+        'UnderwayEventsForJoinedTeamsQuery',
+        'FinishedEventsForJoinedTeamsQuery',
+      ],
     })
+
     res
       .then(() => {
         this.$toast.success('登録しました')


### PR DESCRIPTION
resolve: #247

## この PR で実装される内容
イベント登録時にヘッダーの更新がされない不具合が解消される

## 確認

-   [x] イベント登録後にヘッダーが更新されること
![15cd6377-24d8-4a4a-9dd5-e932d510339c](https://user-images.githubusercontent.com/8841932/172847290-cc75a2f1-e4b6-4a7f-80ed-3682acfb5e62.gif)


## 備考
