### PR TITLE
#169 追加、編集、削除のUIデザインを統一する

### DIFF
--- a/front/components/circle-list/CircleListForm.vue
+++ b/front/components/circle-list/CircleListForm.vue
@@ -8,7 +8,7 @@
           {{ circlePlacement ? circlePlacement.formatted_placement : '' }}
           {{ circle.name }}
           <v-spacer />
-          <v-btn color="success" @click="editCircle">編集</v-btn>
+          <edit-btn @click="editCircle" />
         </template>
       </v-card-title>
       <v-card-text>

--- a/front/components/circle-list/CircleListTable.vue
+++ b/front/components/circle-list/CircleListTable.vue
@@ -19,9 +19,7 @@
         />
         <v-toolbar-title>サークルリスト</v-toolbar-title>
         <v-spacer />
-        <v-btn color="register" icon @click="openCircleListForm">
-          <v-icon>mdi-plus</v-icon>
-        </v-btn>
+        <register-btn @click="openCircleListForm" />
         <v-btn icon @click="toggleShowFilter"
           ><v-icon>mdi-filter-variant</v-icon></v-btn
         >

--- a/front/components/circle-list/form/CircleProductRow.vue
+++ b/front/components/circle-list/form/CircleProductRow.vue
@@ -1,11 +1,12 @@
 <template>
   <v-row>
-    <v-col cols="12" class="text--primary pb-0">
+    <v-col cols="12" class="text--primary pb-0 d-flex">
       {{ circleProduct.circleProductClassification.name }}
       {{ circleProduct.name }}
+      <v-spacer />
       <template v-if="hasMyWantCircleProduct">
-        <v-btn @click="editCircleProduct">編集</v-btn>
-        <v-btn @click="deleteCircleProduct">削除</v-btn>
+        <edit-btn @click="editCircleProduct" />
+        <delete-btn @click="deleteCircleProduct" />
       </template>
     </v-col>
     <v-col cols="12" class="pt-0">

--- a/front/components/common/btn/DeleteBtn.vue
+++ b/front/components/common/btn/DeleteBtn.vue
@@ -1,0 +1,38 @@
+<template>
+  <v-btn color="delete" icon v-bind="$attrs" v-on="listeners">
+    <v-icon>mdi-delete</v-icon>
+  </v-btn>
+</template>
+
+<script lang="ts">
+import { Vue, Component, Prop } from 'nuxt-property-decorator'
+
+@Component({
+  inheritAttrs: false,
+})
+export default class DeleteBtn extends Vue {
+  @Prop({ type: Boolean, default: true })
+  private confirm!: boolean
+
+  @Prop({ type: String })
+  private confirmMessage!: string
+
+  private get listeners() {
+    return {
+      ...this.$listeners,
+      click: this.onClicked,
+    }
+  }
+
+  private async onClicked(event: any) {
+    if (
+      this.confirm &&
+      !(await this.$confirmDialog.confirm(this.confirmMessage))
+    ) {
+      return
+    }
+
+    this.$emit('click', event)
+  }
+}
+</script>

--- a/front/components/common/btn/EditBtn.vue
+++ b/front/components/common/btn/EditBtn.vue
@@ -1,0 +1,21 @@
+<template>
+  <v-btn color="edit" icon v-bind="$attrs" v-on="listeners">
+    <v-icon>mdi-pencil</v-icon>
+  </v-btn>
+</template>
+
+<script lang="ts">
+import { Vue, Component } from 'nuxt-property-decorator'
+
+@Component({
+  inheritAttrs: false,
+})
+export default class EditBtn extends Vue {
+  private get listeners() {
+    return {
+      ...this.$listeners,
+      click: (event: any) => this.$emit('click', event),
+    }
+  }
+}
+</script>

--- a/front/components/common/btn/RegisterBtn.vue
+++ b/front/components/common/btn/RegisterBtn.vue
@@ -1,0 +1,21 @@
+<template>
+  <v-btn color="register" icon v-bind="$attrs" v-on="listeners">
+    <v-icon>mdi-plus</v-icon>
+  </v-btn>
+</template>
+
+<script lang="ts">
+import { Vue, Component } from 'nuxt-property-decorator'
+
+@Component({
+  inheritAttrs: false,
+})
+export default class RegisterBtn extends Vue {
+  private get listeners() {
+    return {
+      ...this.$listeners,
+      click: (event: any) => this.$emit('click', event),
+    }
+  }
+}
+</script>

--- a/front/components/masters/AbstractMasterPage.vue
+++ b/front/components/masters/AbstractMasterPage.vue
@@ -18,18 +18,12 @@
           <v-toolbar>
             <v-toolbar-title>{{ title }}</v-toolbar-title>
             <v-spacer />
-            <v-btn color="register" @click="create"
-              ><v-icon>mdi-plus</v-icon>追加</v-btn
-            >
+            <register-btn @click="create" />
           </v-toolbar>
         </template>
         <template #[`item.actions`]="{ item }">
-          <v-btn color="edit" @click="edit(item)"
-            ><v-icon left>mdi-pencil</v-icon>編集</v-btn
-          >
-          <v-btn color="delete" @click="remove(item)"
-            ><v-icon left>mdi-delete</v-icon>削除</v-btn
-          >
+          <edit-btn @click="edit(item)" />
+          <delete-btn @click="remove(item)" />
         </template>
       </v-data-table>
     </v-col>
@@ -74,11 +68,7 @@ export default abstract class AbstractMasterPage<
     this.isOpenFormDialog = true
   }
 
-  private async remove(model: Model) {
-    if (!(await this.$confirmDialog.confirm())) {
-      return
-    }
-
+  private remove(model: Model) {
     const res = this.$apollo.mutate({
       mutation: this.deleteMutation,
       variables: {

--- a/front/nuxt.config.js
+++ b/front/nuxt.config.js
@@ -38,6 +38,7 @@ export default {
     '~/plugins/apollo/inject-default-apollo-client',
     '~/plugins/confirm-dialog',
     '~/plugins/file-downloader',
+    '~/plugins/register-btn-components',
   ],
 
   router: {

--- a/front/pages/mypage/index.vue
+++ b/front/pages/mypage/index.vue
@@ -23,9 +23,7 @@
       <v-card-title>
         所属チーム
         <v-spacer />
-        <v-btn icon nuxt color="register" to="teams/create">
-          <v-icon>mdi-plus</v-icon>
-        </v-btn>
+        <register-btn nuxt to="teams/create" />
       </v-card-title>
       <v-card-text>
         <v-container>

--- a/front/pages/teams/_team_id/index.vue
+++ b/front/pages/teams/_team_id/index.vue
@@ -18,12 +18,11 @@
       </v-card-text>
     </v-card>
     <v-card class="mt-3">
-      <v-card-title>イベント</v-card-title>
-      <v-card-actions>
-        <v-btn color="register" nuxt :to="`/teams/${team.id}/events/create`">
-          イベントを作成
-        </v-btn>
-      </v-card-actions>
+      <v-card-title>
+        イベント
+        <v-spacer />
+        <register-btn nuxt :to="`/teams/${team.id}/events/create`" />
+      </v-card-title>
     </v-card>
     <v-card class="mt-3">
       <v-card-title>マスタ管理</v-card-title>

--- a/front/plugins/register-btn-components.ts
+++ b/front/plugins/register-btn-components.ts
@@ -1,0 +1,8 @@
+import Vue from 'vue'
+import RegisterBtn from '~/components/common/btn/RegisterBtn.vue'
+import EditBtn from '~/components/common/btn/EditBtn.vue'
+import DeleteBtn from '~/components/common/btn/DeleteBtn.vue'
+
+Vue.component('register-btn', RegisterBtn)
+Vue.component('edit-btn', EditBtn)
+Vue.component('delete-btn', DeleteBtn)

--- a/front/test/setup.js
+++ b/front/test/setup.js
@@ -12,6 +12,7 @@ import { config } from '@vue/test-utils'
 import VIconStub from './stubs/VIcon'
 import VValidateTextField from '~/components/form/VValidateTextField.vue'
 import '~/vee-validate/password'
+import '~/plugins/register-btn-components'
 
 Vue.use(Vuetify)
 Vue.use(Vuex)


### PR DESCRIPTION
resolve: #169 

## この PR で実装される内容
追加、編集、削除のボタンがコンポーネント化され、各画面での見た目、操作感あが統一される

## 確認

-   [x] 登録、編集、削除ボタンの見た目が統一されていること
![image](https://user-images.githubusercontent.com/8841932/173610851-44e34c7b-e935-4797-a244-61ecb40deb21.png)
![image](https://user-images.githubusercontent.com/8841932/173610884-526c1a2e-e703-402f-a78e-fdd2f26c5008.png)
![image](https://user-images.githubusercontent.com/8841932/173610912-b57d6e44-dd54-4c08-8f60-7d353218d925.png)
![image](https://user-images.githubusercontent.com/8841932/173610967-2667166b-1d86-40be-909f-01a1bd859d33.png)


-   [x] 削除ボタン押下時に確認ダイアログが出ること
![image](https://user-images.githubusercontent.com/8841932/173611023-b3636190-a0de-4133-91f6-2fd5dcc8ba02.png)

## 備考
