### PR TITLE
#214 サークル、頒布物編集削除時に自分以外にリストに追加している人がいる場合の処理を追加

### DIFF
--- a/front/apollo/mutations/deleteCircleProduct.gql
+++ b/front/apollo/mutations/deleteCircleProduct.gql
@@ -1,5 +1,0 @@
-mutation deleteCircleProductMutation($id: ID!) {
-  deleteCircleProduct(id: $id) {
-    id
-  }
-}

--- a/front/apollo/mutations/unnecessaryCircleProduct.gql
+++ b/front/apollo/mutations/unnecessaryCircleProduct.gql
@@ -1,0 +1,5 @@
+mutation unnecessaryCircleProductMutation($id: ID!) {
+  unnecessaryCircleProduct(id: $id) {
+    id
+  }
+}

--- a/front/apollo/mutations/updateCircleProduct.gql
+++ b/front/apollo/mutations/updateCircleProduct.gql
@@ -1,7 +1,12 @@
 mutation updateCircleProductMutation($id: ID!, $input: CircleProductInput!) {
   updateCircleProduct(id: $id, input: $input) {
-    id
-    name
-    price
+    circleProduct {
+      id
+      name
+      price
+    }
+    updatedWantCircleProduct {
+      id
+    }
   }
 }

--- a/front/components/circle-list/form/CircleForm.vue
+++ b/front/components/circle-list/form/CircleForm.vue
@@ -282,12 +282,10 @@ export default class CircleForm extends Vue {
         if (isApolloError(error)) {
           const errorExtensions = error.graphQLErrors[0].extensions
           if (errorExtensions.category === 'updateDenied') {
-            console.log(errorExtensions)
             this.$toast.error(errorExtensions.message)
             return
           }
 
-          console.log(errorExtensions)
           this.$toasted.global.validationError()
           this.validation.setBackendErrorsFromAppolo(error)
         }

--- a/front/components/circle-list/form/CircleForm.vue
+++ b/front/components/circle-list/form/CircleForm.vue
@@ -161,7 +161,8 @@ export default class CircleForm extends Vue {
   @Prop({ type: Object as PropType<CirclePlacement> })
   private circlePlacement?: CirclePlacement
 
-  private validation: CreateCircleParticipatingInEventInputValidation = new CreateCircleParticipatingInEventInputValidation()
+  private validation: CreateCircleParticipatingInEventInputValidation =
+    new CreateCircleParticipatingInEventInputValidation()
 
   private circleInput: CircleInput = { ...initialCircleInput }
 
@@ -213,6 +214,10 @@ export default class CircleForm extends Vue {
         ? this.updateCircle
         : this.createCircle
       const circle = await postMethod()
+
+      if (!circle) {
+        return
+      }
 
       this.$toast.success('保存しました')
       this.$emit('saved', { circle })
@@ -275,6 +280,14 @@ export default class CircleForm extends Vue {
       })
       .catch((error) => {
         if (isApolloError(error)) {
+          const errorExtensions = error.graphQLErrors[0].extensions
+          if (errorExtensions.category === 'updateDenied') {
+            console.log(errorExtensions)
+            this.$toast.error(errorExtensions.message)
+            return
+          }
+
+          console.log(errorExtensions)
           this.$toasted.global.validationError()
           this.validation.setBackendErrorsFromAppolo(error)
         }

--- a/front/components/circle-list/form/CircleProductForm.vue
+++ b/front/components/circle-list/form/CircleProductForm.vue
@@ -191,9 +191,6 @@ export default class CircleProductForm extends Vue {
   }
 
   private async submitCircleProduct() {
-    const mutationName = this.isCreate
-      ? 'createCircleProduct'
-      : 'updateCircleProduct'
     return await this.$apollo
       .mutate(this.mutateOption)
       .then((res) => {

--- a/front/components/circle-list/form/CircleProductForm.vue
+++ b/front/components/circle-list/form/CircleProductForm.vue
@@ -196,7 +196,21 @@ export default class CircleProductForm extends Vue {
       : 'updateCircleProduct'
     return await this.$apollo
       .mutate(this.mutateOption)
-      .then((res) => res.data![mutationName])
+      .then((res) => {
+        // FIXME: #258 computedで取得したobjectのプロパティへの書き込みを行うことで実装している部分があり、
+        //             バグの温床になっているかつ、コードが複雑化している。issueの通りに直すこと
+        const data = res.data!
+
+        if (this.isCreate) {
+          return data.createCircleProduct
+        }
+
+        if (data.updateCircleProduct.updatedWantCircleProduct) {
+          this.wantCircleProduct!.id =
+            data.updateCircleProduct.updatedWantCircleProduct.id
+        }
+        return data.updateCircleProduct.circleProduct
+      })
       .catch((error) => {
         if (isApolloError(error)) {
           this.$toasted.global.validationError()
@@ -273,10 +287,11 @@ export default class CircleProductForm extends Vue {
     if (!this.circleProduct || !this.circleProduct.wantCircleProducts) {
       return null
     }
-    const targetWantCircleProduct = this.circleProduct!.wantCircleProducts!.find(
-      (wantCircleProduct) =>
-        wantCircleProduct!.careAboutCircle.join_event_id === this.joinEventId
-    )
+    const targetWantCircleProduct =
+      this.circleProduct!.wantCircleProducts!.find(
+        (wantCircleProduct) =>
+          wantCircleProduct!.careAboutCircle.join_event_id === this.joinEventId
+      )
     if (!targetWantCircleProduct) {
       return null
     }

--- a/front/components/circle-list/form/CircleProductRow.vue
+++ b/front/components/circle-list/form/CircleProductRow.vue
@@ -33,7 +33,7 @@ import { PropType } from 'vue'
 import { Vue, Prop, Component, Emit } from 'nuxt-property-decorator'
 import {
   CircleProduct,
-  DeleteCircleProductMutation,
+  UnnecessaryCircleProductMutation,
   User,
   WantCircleProduct,
 } from '~/apollo/graphql'
@@ -73,7 +73,7 @@ export default class CircleListRow extends Vue {
     const id = this.circleProduct.id
     await this.$apollo
       .mutate({
-        mutation: DeleteCircleProductMutation,
+        mutation: UnnecessaryCircleProductMutation,
         variables: { id },
       })
       .catch(() => this.$toast.error('削除に失敗しました'))

--- a/front/pages/teams/_team_id/circle-product-classifications.vue
+++ b/front/pages/teams/_team_id/circle-product-classifications.vue
@@ -25,9 +25,7 @@ import AbstractMasterPage from '~/components/masters/AbstractMasterPage.vue'
     },
   },
 })
-export default class CircleProductClassificationPage extends AbstractMasterPage<
-  CircleProductClassification
-> {
+export default class CircleProductClassificationPage extends AbstractMasterPage<CircleProductClassification> {
   protected readonly headers: DataTableHeader[] = [
     { text: '頒布物分類名', value: 'name' },
     { text: '操作', value: 'actions', sortable: false },

--- a/laravel/app/GraphQL/Mutations/UnnecessaryCircleProduct.php
+++ b/laravel/app/GraphQL/Mutations/UnnecessaryCircleProduct.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\GraphQL\Mutations;
+
+use Auth;
+
+use Illuminate\Support\Arr;
+
+use App\UseCase\CircleProduct\UnnecessaryCircleProduct as UnnecessaryCircleProductUseCase;
+use App\UseCase\CircleProduct\UnnecessaryCircleProductInput;
+
+class UnnecessaryCircleProduct
+{
+    /**
+     * @param  null  $_
+     * @param  array<string, mixed>  $args
+     */
+    public function __invoke($_, array $args)
+    {
+        $data = Arr::except($args, ['directive']);
+        $data['operation_user_id'] = Auth::id();
+        $input = new UnnecessaryCircleProductInput($data);
+        return (new UnnecessaryCircleProductUseCase())->execute($input);
+    }
+}

--- a/laravel/app/GraphQL/Mutations/UpdateCircleParticipatingInEvent.php
+++ b/laravel/app/GraphQL/Mutations/UpdateCircleParticipatingInEvent.php
@@ -2,6 +2,8 @@
 
 namespace App\GraphQL\Mutations;
 
+use Auth;
+
 use App\UseCase\Circle\UpdateCircleParticipatingInEvent as UpdateCircleParticipatingInEventUseCase;
 use App\UseCase\Circle\UpdateCircleParticipatingInEventInput;
 use Illuminate\Support\Arr;
@@ -15,6 +17,7 @@ class UpdateCircleParticipatingInEvent
     public function __invoke($_, array $args)
     {
         $data = Arr::except($args, ['directive']);
+        $data['operation_user_id'] = Auth::id();
         $input = new UpdateCircleParticipatingInEventInput($data);
         return (new UpdateCircleParticipatingInEventUseCase())->execute($input);
     }

--- a/laravel/app/GraphQL/Mutations/UpdateCircleProduct.php
+++ b/laravel/app/GraphQL/Mutations/UpdateCircleProduct.php
@@ -2,6 +2,8 @@
 
 namespace App\GraphQL\Mutations;
 
+use Auth;
+
 use App\UseCase\CircleProduct\UpdateCircleProduct as UpdateCircleProductUseCase;
 use App\UseCase\CircleProduct\UpdateCircleProductInput;
 use Illuminate\Support\Arr;
@@ -15,6 +17,7 @@ class UpdateCircleProduct
     public function __invoke($_, array $args)
     {
         $data = Arr::except($args, ['directive']);
+        $data['operation_user_id'] = Auth::id();
         $input = new UpdateCircleProductInput($data);
         return (new UpdateCircleProductUseCase())->execute($input);
     }

--- a/laravel/app/Models/CareAboutCircle.php
+++ b/laravel/app/Models/CareAboutCircle.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Builder;
 
 class CareAboutCircle extends Model
 {
@@ -19,5 +20,13 @@ class CareAboutCircle extends Model
     public function joinEvent(): BelongsTo
     {
         return $this->belongsTo(JoinEvent::class);
+    }
+
+    public function scopeWhereHasUser(Builder $builder, string $userId)
+    {
+        return $builder->whereHas(
+            'joinEvent',
+            fn (Builder $whereHasBuilder) => $whereHasBuilder->where('user_id', $userId)
+        );
     }
 }

--- a/laravel/app/Models/WantCircleProduct.php
+++ b/laravel/app/Models/WantCircleProduct.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
@@ -29,5 +30,13 @@ class WantCircleProduct extends Model
     public function circleProduct(): BelongsTo
     {
         return $this->belongsTo(CircleProduct::class);
+    }
+
+    public function scopeWhereHasUser(Builder $builder, string $userId): Builder
+    {
+        return $builder->whereHas(
+            'careAboutCircle',
+            fn (Builder $whereHasBuilder) => $whereHasBuilder->whereHasUser($userId)
+        );
     }
 }

--- a/laravel/app/UseCase/Circle/UpdateCircleParticipatingInEventInput.php
+++ b/laravel/app/UseCase/Circle/UpdateCircleParticipatingInEventInput.php
@@ -8,6 +8,7 @@ class UpdateCircleParticipatingInEventInput extends CreateCircleParticipatingInE
     {
         return array_merge(parent::rules(), [
             'id' => 'required',
+            'operation_user_id' => 'required',
         ]);
     }
 
@@ -15,6 +16,7 @@ class UpdateCircleParticipatingInEventInput extends CreateCircleParticipatingInE
     {
         return array_merge(parent::rules(), [
             'id' => 'サークル番号',
+            'operation_user_id' => '操作ユーザ番号',
         ]);
     }
 

--- a/laravel/app/UseCase/CircleProduct/UnnecessaryCircleProduct.php
+++ b/laravel/app/UseCase/CircleProduct/UnnecessaryCircleProduct.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\UseCase\CircleProduct;
+
+use App\Models\CareAboutCircle;
+use App\Models\CircleProduct;
+use App\UseCase\UseCase;
+
+class UnnecessaryCircleProduct extends UseCase
+{
+    public function execute(UnnecessaryCircleProductInput $input)
+    {
+        $circleProduct = CircleProduct::findOrFail($input->get('id'));
+        $careAboutCircle = $this->findCareAboutCircleByOperationUser($input->get('operation_user_id'), $circleProduct);
+
+        $wantCircleProducts = $circleProduct
+            ->wantCircleProducts()
+            ->where('care_about_circle_id', $careAboutCircle->id)
+            ->get()
+            ->each(
+                fn ($wantCircleProduct) => $wantCircleProduct->delete()
+            );
+
+        if (!$circleProduct->wantCircleProducts()->exists()) {
+            $circleProduct->delete();
+        }
+
+        return $circleProduct;
+    }
+
+    private function findCareAboutCircleByOperationUser(string $operationUserId, CircleProduct $circleProduct): CareAboutCircle
+    {
+        return $circleProduct
+            ->circlePlacement
+            ->careAboutCircles()
+            ->whereHasUser($operationUserId)
+            ->firstOrFail();
+    }
+}

--- a/laravel/app/UseCase/CircleProduct/UnnecessaryCircleProductInput.php
+++ b/laravel/app/UseCase/CircleProduct/UnnecessaryCircleProductInput.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\UseCase\CircleProduct;
+
+use App\UseCase\UseCaseInput;
+
+class UnnecessaryCircleProductInput extends UseCaseInput
+{
+    protected function rules(): array
+    {
+        return [
+            'id' => 'required',
+            'operation_user_id' => 'required',
+        ];
+    }
+
+    protected function attributes(): array
+    {
+        return [
+            'id' => '頒布物番号',
+            'operation_user_id' => '操作しているユーザ番号',
+        ];
+    }
+}

--- a/laravel/app/UseCase/CircleProduct/UpdateCircleProduct.php
+++ b/laravel/app/UseCase/CircleProduct/UpdateCircleProduct.php
@@ -4,6 +4,8 @@ namespace App\UseCase\CircleProduct;
 
 use App\Models\CircleProduct;
 use App\UseCase\UseCase;
+use App\UseCase\WantCircleProduct\CreateWantCircleProduct;
+use App\UseCase\WantCircleProduct\CreateWantCircleProductInput;
 
 class UpdateCircleProduct extends UseCase
 {
@@ -11,8 +13,43 @@ class UpdateCircleProduct extends UseCase
     {
         $circleProductData = $input->toArray();
         $circleProduct = CircleProduct::findOrFail($circleProductData['id']);
-        $circleProduct->update($circleProductData);
+
+        // note: 名前が変更されていて、他ユーザもほしいものに登録されている頒布物の場合は、
+        //       更新してしまうと他ユーザのほしいものも一緒に変更されてしまうため、
+        //       直接更新せずに、新規で頒布物を登録し、ほしいもののレコードは新しい頒布物に付け替える形にしている
+        $operationUserId = $input->get('operation_user_id');
+        $isNameChanged = $input->get('name') !== $circleProduct->name;
+        if ($isNameChanged && $this->isExistsWantCircleProductWhereHasOtherUser($operationUserId, $circleProduct)) {
+            $operationUserWantCircleProduct = $circleProduct
+                ->wantCircleProducts()
+                ->whereHasUser($operationUserId)
+                ->firstOrFail();
+
+            $operationUserWantCircleProduct->delete();
+
+            $createCircleProductInput = new CreateCircleProductInput($input->toArray());
+            $circleProduct = (new CreateCircleProduct())->execute($createCircleProductInput);
+
+            $createWantCircleProductValues = collect($operationUserWantCircleProduct->toArray())
+                ->only([
+                    'quantity',
+                    'want_priority_id',
+                ])
+                ->put('join_event_id', $operationUserWantCircleProduct->careAboutCircle->join_event_id)
+                ->put('circle_product_id', $circleProduct->id)
+                ->toArray();
+            $createWantCircleProductInput = new CreateWantCircleProductInput($createWantCircleProductValues);
+            (new CreateWantCircleProduct)->execute($createWantCircleProductInput);
+        } else {
+            $circleProduct->update($circleProductData);
+        }
+
         $circleProduct->refresh();
         return $circleProduct;
+    }
+
+    private function isExistsWantCircleProductWhereHasOtherUser(string $operationUserId, CircleProduct $circleProduct): bool
+    {
+        return $circleProduct->wantCircleProducts()->count() > 1;
     }
 }

--- a/laravel/app/UseCase/CircleProduct/UpdateCircleProductInput.php
+++ b/laravel/app/UseCase/CircleProduct/UpdateCircleProductInput.php
@@ -8,6 +8,7 @@ class UpdateCircleProductInput extends CreateCircleProductInput
     {
         return array_merge(parent::rules(), [
             'id' => 'required',
+            'operation_user_id' => 'required',
         ]);
     }
 
@@ -15,6 +16,7 @@ class UpdateCircleProductInput extends CreateCircleProductInput
     {
         return array_merge(parent::attributes(), [
             'id' => '頒布物番号',
+            'operation_user_id' => '操作ユーザ番号',
         ]);
     }
 }

--- a/laravel/app/UseCase/UpdateDeniedException.php
+++ b/laravel/app/UseCase/UpdateDeniedException.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\UseCase;
+
+use Exception;
+
+use Nuwave\Lighthouse\Exceptions\RendersErrorsExtensions;
+
+class UpdateDeniedException extends Exception implements RendersErrorsExtensions
+{
+    public function isClientSafe(): bool
+    {
+        return true;
+    }
+
+    public function getCategory(): string
+    {
+        return 'updateDenied';
+    }
+
+    public function extensionsContent(): array
+    {
+        return [
+            'message' => $this->message,
+        ];
+    }
+}

--- a/laravel/app/UseCase/UseCaseInput.php
+++ b/laravel/app/UseCase/UseCaseInput.php
@@ -29,6 +29,11 @@ abstract class UseCaseInput
         return $this->input;
     }
 
+    public function get(string $key, $default = null)
+    {
+        return array_key_exists($key, $this->input) ? $this->input[$key] : $default;
+    }
+
     protected function makeValidator(array $input): Validator
     {
         return ValidatorFacade::make($input, $this->rules(), [], $this->attributes());

--- a/laravel/database/datasetFactories/CircleDatasetFactory.php
+++ b/laravel/database/datasetFactories/CircleDatasetFactory.php
@@ -37,7 +37,7 @@ class CircleDatasetFactory
         $circle->load([
             'circlePlacements.careAboutCircles'
         ]);
-        $circlePlacements = $circle->circlePlacements;
+        $circlePlacements = $circle instanceof Circle ? $circle->circlePlacements : $circle->flatMap(fn ($circle) => $circle->circlePlacements);
         $careAboutCircle = $circlePlacements
             ->flatMap(fn ($circlePlacement) => $circlePlacement->careAboutCircles);
         $circleProducts = $circlePlacements

--- a/laravel/database/datasetFactories/EventDatasetFactory.php
+++ b/laravel/database/datasetFactories/EventDatasetFactory.php
@@ -28,6 +28,7 @@ class EventDatasetFactory
                 )
                 ->state(['is_production_day' => true])
         )->create();
+        $eventDates = $event->eventDates;
         EventAffiliationTeam::factory()
             ->create([
                 'event_id' => $event->id,
@@ -46,6 +47,6 @@ class EventDatasetFactory
                     'join_event_id' => $joinEvent->id,
                 ]);
         });
-        return array_merge($teamDataset, compact('event', 'joinEvent'));
+        return array_merge($teamDataset, compact('event', 'eventDates', 'joinEvent'));
     }
 }

--- a/laravel/graphql/circleProduct.graphql
+++ b/laravel/graphql/circleProduct.graphql
@@ -10,6 +10,11 @@ type CircleProduct {
     updated_at: DateTime
 }
 
+type UpdatedCircleProduct {
+    circleProduct: CircleProduct!
+    updatedWantCircleProduct: WantCircleProduct
+}
+
 input CircleProductInput {
     circle_placement_id: ID
     circle_product_classification_id: ID!
@@ -33,7 +38,7 @@ extend type Mutation @guard {
     updateCircleProduct(
         id: ID!,
         input: CircleProductInput! @spread
-    ): CircleProduct!
+    ): UpdatedCircleProduct!
         @field(
             resolver: "App\\GraphQL\\Mutations\\UpdateCircleProduct"
         )

--- a/laravel/graphql/circleProduct.graphql
+++ b/laravel/graphql/circleProduct.graphql
@@ -37,7 +37,10 @@ extend type Mutation @guard {
         @field(
             resolver: "App\\GraphQL\\Mutations\\UpdateCircleProduct"
         )
-    deleteCircleProduct(
+    unnecessaryCircleProduct(
         id: ID!
-    ): CircleProduct @delete
+    ): CircleProduct
+        @field(
+            resolver: "App\\GraphQL\\Mutations\\UnnecessaryCircleProduct"
+        )
 }

--- a/laravel/tests/Graphql/CircleProductTest.php
+++ b/laravel/tests/Graphql/CircleProductTest.php
@@ -112,6 +112,67 @@ class CircleProductTest extends TestCase
         $this->assertEquals($updateCircleProductInput['circle_product_classification_id'], $responseData['circleProductClassification']['id']);
     }
 
+    public function testUpdateCircleProductWhenMultiUser()
+    {
+        $dataset = (new CircleDatasetFactory())->one()->create();
+        $user = $dataset['user'];
+        $circle = $dataset['circle'];
+        $circlePlacement = $circle->circlePlacements()->first();
+        $circleProduct = $circlePlacement->circleProducts()->first();
+        $circleProductDefinition = CircleProduct::factory()->definition();
+        $team = $dataset['team'];
+        $circleProductClassification = $team->circleProductClassifications()->inRandomOrder()->first();
+        $updateCircleProductInput = array_merge($circleProductDefinition, [
+            'circle_placement_id' => $circlePlacement->id,
+            'circle_product_classification_id' => $circleProductClassification->id,
+        ]);
+        $loginUserWantCircleProduct = $circleProduct
+            ->wantCircleProducts()
+            ->whereHasUser($user->id)
+            ->firstOrFail();
+        $careAboutCircle = $loginUserWantCircleProduct->careAboutCircle;
+        $otherUserWantCircleProduct = WantCircleProduct::factory([
+            'circle_product_id' => $circleProduct->id,
+        ])->create();
+
+        $response = $this
+            ->actingAsUser($user)
+            ->graphQL('
+                mutation updateCircleProduct($id: ID!, $input: CircleProductInput!) {
+                    updateCircleProduct(id: $id, input: $input) {
+                        id
+                        name
+                        price
+                        circlePlacement {
+                            id
+                        }
+                        circleProductClassification {
+                            id
+                        }
+                    }
+                }
+            ', [
+                'id' => $circleProduct->id,
+                'input' => $updateCircleProductInput,
+            ]);
+
+        $expectedCircleProductData = Arr::except($updateCircleProductInput, ['circle_placement_id', 'circle_product_classification_id']);
+        $response
+            ->assertStatus(200)
+            ->assertJson([
+                'data' => [
+                    'updateCircleProduct' => $expectedCircleProductData,
+                ]
+            ]);
+        $responseData = $response->json('data.updateCircleProduct');
+
+        $this->assertDatabaseHas('circle_products', $expectedCircleProductData);
+        $this->assertEquals($updateCircleProductInput['circle_placement_id'], $responseData['circlePlacement']['id']);
+        $this->assertEquals($updateCircleProductInput['circle_product_classification_id'], $responseData['circleProductClassification']['id']);
+        $this->assertDatabaseMissing('want_circle_products', ['id' => $loginUserWantCircleProduct->id]);
+        $this->assertDatabaseHas('want_circle_products', ['care_about_circle_id' => $careAboutCircle->id, 'circle_product_id' => $responseData['id']]);
+    }
+
     public function testUnnecessaryCircleProductWhenOneUser()
     {
         $dataset = (new CircleDatasetFactory())->one()->create();

--- a/laravel/tests/Graphql/CircleProductTest.php
+++ b/laravel/tests/Graphql/CircleProductTest.php
@@ -81,14 +81,16 @@ class CircleProductTest extends TestCase
             ->graphQL('
                 mutation updateCircleProduct($id: ID!, $input: CircleProductInput!) {
                     updateCircleProduct(id: $id, input: $input) {
-                        id
-                        name
-                        price
-                        circlePlacement {
+                        circleProduct {
                             id
-                        }
-                        circleProductClassification {
-                            id
+                            name
+                            price
+                            circlePlacement {
+                                id
+                            }
+                            circleProductClassification {
+                                id
+                            }
                         }
                     }
                 }
@@ -102,10 +104,12 @@ class CircleProductTest extends TestCase
             ->assertStatus(200)
             ->assertJson([
                 'data' => [
-                    'updateCircleProduct' => $expectedCircleProductData,
+                    'updateCircleProduct' => [
+                        'circleProduct' => $expectedCircleProductData,
+                    ]
                 ]
             ]);
-        $responseData = $response->json('data.updateCircleProduct');
+        $responseData = $response->json('data.updateCircleProduct.circleProduct');
 
         $this->assertDatabaseHas('circle_products', $expectedCircleProductData);
         $this->assertEquals($updateCircleProductInput['circle_placement_id'], $responseData['circlePlacement']['id']);
@@ -140,14 +144,16 @@ class CircleProductTest extends TestCase
             ->graphQL('
                 mutation updateCircleProduct($id: ID!, $input: CircleProductInput!) {
                     updateCircleProduct(id: $id, input: $input) {
-                        id
-                        name
-                        price
-                        circlePlacement {
+                        circleProduct {
                             id
-                        }
-                        circleProductClassification {
-                            id
+                            name
+                            price
+                            circlePlacement {
+                                id
+                            }
+                            circleProductClassification {
+                                id
+                            }
                         }
                     }
                 }
@@ -161,10 +167,12 @@ class CircleProductTest extends TestCase
             ->assertStatus(200)
             ->assertJson([
                 'data' => [
-                    'updateCircleProduct' => $expectedCircleProductData,
+                    'updateCircleProduct' => [
+                        'circleProduct' => $expectedCircleProductData,
+                    ]
                 ]
             ]);
-        $responseData = $response->json('data.updateCircleProduct');
+        $responseData = $response->json('data.updateCircleProduct.circleProduct');
 
         $this->assertDatabaseHas('circle_products', $expectedCircleProductData);
         $this->assertEquals($updateCircleProductInput['circle_placement_id'], $responseData['circlePlacement']['id']);

--- a/laravel/tests/Graphql/CircleTest.php
+++ b/laravel/tests/Graphql/CircleTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Graphql;
 
+use App\Models\CareAboutCircle;
 use Illuminate\Foundation\Testing\WithFaker;
 use Illuminate\Support\Arr;
 
@@ -15,6 +16,7 @@ use App\Models\EventAffiliationTeam;
 use App\Models\UserAffiliationTeam;
 use App\Models\JoinEvent;
 use App\Models\JoinEventDate;
+use Database\DatasetFactories\CircleDatasetFactory;
 
 class CircleTest extends TestCase
 {
@@ -104,6 +106,95 @@ class CircleTest extends TestCase
 
     public function testUpdateCircleParticipatingInEvent()
     {
-        $this->markTestSkipped('Factoryを整備したら追加する');
+        $dataset = (new CircleDatasetFactory())
+            ->one()
+            ->create();
+        $user = $dataset['user'];
+        $team = $dataset['team'];
+
+        $placementValues = collect(CirclePlacement::factory()->definition())
+            ->except('circle_id', 'event_date_id', 'circle_placement_classification_id')
+            ->put('event_date_id', $dataset['eventDates']->random()->id)
+            ->put('circle_placement_classification_id', $team->circlePlacementClassifications->random()->id)
+            ->toArray();
+
+        $updateCircleParticipatingInEventInput = [
+            'circle' => Circle::factory()->definition(),
+            'placement' => $placementValues,
+        ];
+
+        $response = $this
+            ->actingAsUser($user)
+            ->graphQL('
+                mutation updateCircleParticipatingInEvent($id: ID!, $input: CreateCircleParticipatingInEventInput!) {
+                    updateCircleParticipatingInEvent(id: $id, input: $input) {
+                        id
+                        circle {
+                            id
+                            name
+                            kana
+                            memo
+                        }
+                    }
+                }
+            ', [
+                'id' => $dataset['circle']->id,
+                'input' => $updateCircleParticipatingInEventInput
+            ]);
+        $responseData = $response->json('data.updateCircleParticipatingInEvent');
+
+        $circle = Circle::findOrFail($responseData['circle']['id']);
+
+        $placement = CirclePlacement::findOrFail($responseData['id']);
+        $expectedPlacement = $updateCircleParticipatingInEventInput['placement'];
+        $expectedPlacement['circle_id'] = $circle->id;
+        $assertionPlacement = Arr::except($placement->toArray(), ['id', 'created_at', 'updated_at']);
+        $this->assertEquals($expectedPlacement, $assertionPlacement);
+    }
+
+
+    public function testUpdateCircleParticipatingInEventWhenHasOtherUserCareAboutCircle()
+    {
+        $dataset = (new CircleDatasetFactory())
+            ->one()
+            ->create();
+        $user = $dataset['user'];
+        $team = $dataset['team'];
+        CareAboutCircle::factory([
+            'circle_placement_id' => $dataset['circlePlacements']->first()->id,
+        ])->create();
+
+        $placementValues = collect(CirclePlacement::factory()->definition())
+            ->except('circle_id', 'event_date_id', 'circle_placement_classification_id')
+            ->put('event_date_id', $dataset['eventDates']->random()->id)
+            ->put('circle_placement_classification_id', $team->circlePlacementClassifications->random()->id)
+            ->toArray();
+
+        $updateCircleParticipatingInEventInput = [
+            'circle' => Circle::factory()->definition(),
+            'placement' => $placementValues,
+        ];
+
+        $response = $this
+            ->actingAsUser($user)
+            ->graphQL('
+                mutation updateCircleParticipatingInEvent($id: ID!, $input: CreateCircleParticipatingInEventInput!) {
+                    updateCircleParticipatingInEvent(id: $id, input: $input) {
+                        id
+                        circle {
+                            id
+                            name
+                            kana
+                            memo
+                        }
+                    }
+                }
+            ', [
+                'id' => $dataset['circle']->id,
+                'input' => $updateCircleParticipatingInEventInput
+            ]);
+
+        $errors = $response->json('errors');
+        $this->assertEquals($errors[0]['extensions']['category'], 'updateDenied');
     }
 }


### PR DESCRIPTION
resolve: #214 

## この PR で実装される内容
 - サークル編集時に、ログインユーザ以外に該当サークルをチェックしているユーザか、お気に入りにしているユーザがいる場合、更新を不可にする
 - 頒布物編集時にログインユーザ以外に該当頒布物を欲しがっているユーザがいる場合、頒布物を更新する代わりに頒布物を追加、欲しいレコードを付け替える
 - 頒布物削除時に、ログインユーザ以外に該当頒布物を欲しがっているユーザがいる場合、頒布物は削除せずに、欲しいレコードのみを削除する

## 確認

-   [x] 単体の時は今まで通り動作すること
![b965143f-ee58-4b2d-8498-12752bc1f6bc](https://user-images.githubusercontent.com/8841932/174057167-567e941e-6554-4c1e-acae-a6b42e21d75e.gif)

-   [x] 頒布物に関連ユーザがいる場合、レコードの更新をした際、元の頒布物が消えず、欲しいもののすげ替えができていること
![8db9c0da-9f43-424c-95b0-82c324b0266e](https://user-images.githubusercontent.com/8841932/174063318-1e3eecce-30bb-47a7-81b3-0e417ea7d4b8.gif)

-   [x] 頒布物に関連するユーザがいる場合、削除した際に、欲しいもののみ消えること
![63186e34-d4d5-4205-8615-cdb43804c4af](https://user-images.githubusercontent.com/8841932/174063432-b829ac2e-2a6d-4561-82a8-5e45c4f85cd5.gif)

-   [x] サークル編集時に、関連ユーザがいる場合、更新できないこと 
![cb042be5-7c04-4176-8a11-741636a6bf74](https://user-images.githubusercontent.com/8841932/174057249-7be81778-55e2-4634-9da5-1098546112bf.gif)


## 備考
