### PR TITLE
#254 全体リストから頒布物を追加しようとするとエラーになる不具合の解消

### DIFF
--- a/laravel/app/UseCase/WantCircleProduct/CreateWantCircleProduct.php
+++ b/laravel/app/UseCase/WantCircleProduct/CreateWantCircleProduct.php
@@ -8,27 +8,44 @@ use App\Models\{
     WantCircleProduct,
 };
 use App\UseCase\UseCase;
+use App\UseCase\CareAboutCircle\CreateCareAboutCircle;
+use App\UseCase\CareAboutCircle\CreateCareAboutCircleInput;
 
 class CreateWantCircleProduct extends UseCase
 {
     public function execute(CreateWantCircleProductInput $input)
     {
         $wantCircleProductData = $input->toArray();
-        $careAboutCircle = $this->findCareAboutCircle($input);
+        $careAboutCircle = $this->findOrCreateCareAboutCircle($input);
         $wantCircleProductData['care_about_circle_id'] = $careAboutCircle->id;
 
         $wantCircleProduct = WantCircleProduct::create($wantCircleProductData);
         return $wantCircleProduct;
     }
 
-    private function findCareAboutCircle(CreateWantCircleProductInput $input)
+    private function findOrCreateCareAboutCircle(CreateWantCircleProductInput $input): CareAboutCircle
     {
         $circlePlacementId = CircleProduct::findOrFail($input->toArray()['circle_product_id'])
             ->circlePlacement
             ->id;
 
-        return CareAboutCircle::where('circle_placement_id', $circlePlacementId)
+        $careAboutCircle = CareAboutCircle::where('circle_placement_id', $circlePlacementId)
             ->where('join_event_id', $input->toArray()['join_event_id'])
-            ->firstOrFail();
+            ->first();
+
+        if ($careAboutCircle) {
+            return $careAboutCircle;
+        }
+
+        return $this->createCareAboutCircle($input);
+    }
+
+    private function createCareAboutCircle(CreateWantCircleProductInput $input)
+    {
+        $input = new CreateCareAboutCircleInput([
+            'circle_placement_id' => $input->toArray()['circle_product_id'],
+            'join_event_id' => $input->toArray()['join_event_id'],
+        ]);
+        return (new CreateCareAboutCircle())->execute($input);
     }
 }


### PR DESCRIPTION
resolve: #254 

## この PR で実装される内容
全体リストから頒布物を追加しようとした際にエラーになる不具合が解消される
　→　気にかけてないサークルに対して頒布物の追加をしようとしていたため、該当レコードが取得できずにエラーになっていた
　　→　頒布物を追加しようとしているということは、気に掛けたいとみなして、レコードが登録されるようにした

## 確認

-   [ ] 全体リストから頒布物登録ができること
![22e7415a-1f66-4967-b83a-4c6e6ae34e22](https://user-images.githubusercontent.com/8841932/174066238-2a04fcde-a770-484e-bb9d-c72ab55fe0f4.gif)

## 備考
