### PR TITLE
#262 サークルリスト画面のデフォルトの並び順を配置順にする

### DIFF
--- a/laravel/app/GraphQL/Queries/JoinEventCircleLists.php
+++ b/laravel/app/GraphQL/Queries/JoinEventCircleLists.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\GraphQL\Queries;
+
+use App\Models\ViewCircleList;
+
+class JoinEventCircleLists
+{
+    /**
+     * @param  null  $_
+     * @param  array<string, mixed>  $args
+     */
+    public function __invoke($_, array $args)
+    {
+        return ViewCircleList::where('join_event_id', $args['join_event_id'])
+            ->orderByPlacement()
+            ->get();
+    }
+}

--- a/laravel/app/GraphQL/Queries/TeamCircleLists.php
+++ b/laravel/app/GraphQL/Queries/TeamCircleLists.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\GraphQL\Queries;
+
+use App\Models\ViewCircleList;
+
+class TeamCircleLists
+{
+    /**
+     * @param  null  $_
+     * @param  array<string, mixed>  $args
+     */
+    public function __invoke($_, array $args)
+    {
+        return ViewCircleList::where('team_id', $args['team_id'])
+            ->where('event_id', $args['event_id'])
+            ->orderByPlacement()
+            ->get();
+    }
+}

--- a/laravel/app/Models/ViewCircleList.php
+++ b/laravel/app/Models/ViewCircleList.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 /**
@@ -83,6 +84,16 @@ class ViewCircleList extends Model
     public function circleProductClassification(): BelongsTo
     {
         return $this->belongsTo(CircleProductClassification::class);
+    }
+
+    public function scopeOrderByPlacement(Builder $builder): Builder
+    {
+        return $builder
+            ->orderBy('event_date_id')
+            ->orderBy('placement_hole')
+            ->orderBy('placement_line')
+            ->orderBy('placement_number')
+            ->orderBy('placement_a_or_b');
     }
 
     public function getPlacementFullAttribute(): string

--- a/laravel/graphql/circleList.graphql
+++ b/laravel/graphql/circleList.graphql
@@ -48,8 +48,10 @@ type MadeExcel {
 }
 
 extend type Query @guard {
-    joinEventCircleLists(join_event_id: ID! @eq): [CircleList!]! @all(model: "App\\Models\\ViewCircleList")
-    teamCircleLists(team_id: ID! @eq, event_id: ID! @eq): [CircleList!]! @all(model: "App\\Models\\ViewCircleList")
+    joinEventCircleLists(join_event_id: ID!): [CircleList!]!
+        @field(resolver: "App\\GraphQL\\Queries\\JoinEventCircleLists")
+    teamCircleLists(team_id: ID!, event_id: ID!): [CircleList!]!
+        @field(resolver: "App\\GraphQL\\Queries\\TeamCircleLists")
 }
 
 extend type Mutation @guard {


### PR DESCRIPTION
resolve: #262 

## この PR で実装される内容
サークルリスト画面のデフォルトの並び順が配置順になる

## 確認

-   [x] 並び替えがきいていること
![image](https://user-images.githubusercontent.com/8841932/174118393-3b41a8d5-2619-4195-b442-a4668e3a0f26.png)
![image](https://user-images.githubusercontent.com/8841932/174118418-05c66951-fc02-4804-88c6-72e0f7b285de.png)


## 備考
