### PR TITLE
#281 サークルリスト行の編集方法をデフォルトクリックに変更し、ダブルクリックにも設定できるようにする

### DIFF
--- a/front/components/circle-list/form/CircleProductRow.vue
+++ b/front/components/circle-list/form/CircleProductRow.vue
@@ -25,13 +25,13 @@
         {{ wantCircleProduct.careAboutCircle.joinEvent.user.name }}
       </v-chip>
       <v-tooltip top>
-        <template v-slot:activator="{ on, attrs }">
+        <template #activator="{ on, attrs }">
           <v-btn
             v-if="!hasMyWantCircleProduct"
             icon
+            v-bind="attrs"
             @click="wantMeToo"
             v-on="on"
-            v-bind="attrs"
           >
             <v-icon>mdi-cart-plus</v-icon>
           </v-btn>

--- a/front/components/circle-list/table/CircleListTableSetting.vue
+++ b/front/components/circle-list/table/CircleListTableSetting.vue
@@ -1,0 +1,93 @@
+<template>
+  <v-dialog v-model="isOpenSync">
+    <v-card>
+      <v-card-title> 設定 </v-card-title>
+      <v-card-subtitle>※ 端末ごとに保存されます。</v-card-subtitle>
+      <v-card-text>
+        <v-row>
+          <v-col cols="12">
+            <v-select
+              v-model="settings.howOpenCircleListForm"
+              :items="howOpenCircleListFormOptions"
+              item-text="text"
+              item-value="value"
+              label="サークルリスト行の編集方法"
+              :persistent-hint="true"
+              hint="スマートフォン、ダブレットからアクセスしている場合、ダブルクリックは反応しません。クリックをご使用ください。"
+            />
+          </v-col>
+        </v-row>
+      </v-card-text>
+    </v-card>
+  </v-dialog>
+</template>
+
+<script lang="ts">
+import { PropType } from 'vue'
+import { Vue, PropSync, Component, Watch, Model } from 'nuxt-property-decorator'
+
+type HowOpenCircleListValue = 'click' | 'dblclick'
+type HowOpenCircleListOption = {
+  value: HowOpenCircleListValue
+  text: string
+}
+export type CircleListTableSettings = {
+  howOpenCircleListForm: HowOpenCircleListValue
+}
+
+@Component({})
+export default class CircleListTableSetting extends Vue {
+  @PropSync('isOpen', { type: Boolean, required: true })
+  private isOpenSync!: Boolean
+
+  @Model('update:value', {
+    type: Object as PropType<CircleListTableSettings>,
+    required: true,
+  })
+  private value!: CircleListTableSettings
+
+  private isMounted: boolean = false
+
+  private get settings(): CircleListTableSettings {
+    return this.value
+  }
+
+  private set settings(value) {
+    this.$emit('update:value', value)
+  }
+
+  @Watch('value', { deep: true })
+  private onChangeOptions() {
+    if (this.isMounted) {
+      localStorage.circleListTableOptions = JSON.stringify(this.value)
+    }
+  }
+
+  private howOpenCircleListFormOptions: HowOpenCircleListOption[] = [
+    {
+      value: 'click',
+      text: 'クリック',
+    },
+    {
+      value: 'dblclick',
+      text: 'ダブルクリック',
+    },
+  ]
+
+  public async mounted() {
+    const options = localStorage.getItem('circleListTableOptions')
+    if (options) {
+      try {
+        this.settings = JSON.parse(options)
+      } catch (e) {
+        localStorage.removeItem('circleListTableOptions')
+      }
+    }
+
+    // HACK: localStorageから読んだ値でonChangeOptionsが反応しないように描画させた後にisMountedの更新をかけている
+    //       そもそもマウント終わったかどうかで分岐させるのもスマートではないので、もっといい方法あれば修正したい。
+    await this.$nextTick()
+    this.isMounted = true
+  }
+}
+</script>

--- a/front/components/common/btn/DeleteBtn.vue
+++ b/front/components/common/btn/DeleteBtn.vue
@@ -1,6 +1,6 @@
 <template>
   <v-tooltip top>
-    <template v-slot:activator="{ on, attrs }">
+    <template #activator="{ on, attrs }">
       <v-btn
         color="delete"
         icon

--- a/front/components/common/btn/EditBtn.vue
+++ b/front/components/common/btn/EditBtn.vue
@@ -1,6 +1,6 @@
 <template>
   <v-tooltip top>
-    <template v-slot:activator="{ on, attrs }">
+    <template #activator="{ on, attrs }">
       <v-btn
         color="edit"
         icon

--- a/front/components/common/btn/RegisterBtn.vue
+++ b/front/components/common/btn/RegisterBtn.vue
@@ -1,6 +1,6 @@
 <template>
   <v-tooltip top>
-    <template v-slot:activator="{ on, attrs }">
+    <template #activator="{ on, attrs }">
       <v-btn
         color="register"
         icon

--- a/front/components/favorites/FavoriteButton.vue
+++ b/front/components/favorites/FavoriteButton.vue
@@ -1,6 +1,6 @@
 <template>
   <v-tooltip top>
-    <template v-slot:activator="{ on, attrs }">
+    <template #activator="{ on, attrs }">
       <v-btn
         icon
         color="favorite"


### PR DESCRIPTION
resolve: #281 

## この PR で実装される内容
サークルリストの行を選択（編集）する際に、今まではダブルクリックで編集モーダルを表示するようにしていたが、シングルクリックをデフォルトにし、ダブルクリックに変更できるような設定ができるようにした

## 確認

-   [x] クリック、ダブルクリックの設定ができ、リロードしても維持されること
-   [x] 設定どおりの方法でモーダルが開くこと
![519aa3d6-c2a5-413e-83d2-ea5b3252a3c6](https://user-images.githubusercontent.com/8841932/175603054-59950d79-e4d5-4295-a9a7-fa07f8317aa0.gif)


## 備考
スマホ、タブレットだとダブルクリックができないため、クリックデフォルトにした