### PR TITLE
#285 スマホから見た際に配置を入力しやすくする

### DIFF
--- a/front/components/circle-list/form/CircleForm.vue
+++ b/front/components/circle-list/form/CircleForm.vue
@@ -20,7 +20,7 @@
       </v-row>
 
       <v-row dense>
-        <v-col cols="4">
+        <v-col cols="6" sm="4">
           <v-validate-select
             v-model="circlePlacementInput.event_date_id"
             :items="eventDates"
@@ -29,7 +29,7 @@
             :validation="validation.getItem('placement.event_date_id')"
           />
         </v-col>
-        <v-col cols="2">
+        <v-col cols="6" sm="2">
           <v-validate-select
             v-model="circlePlacementInput.hole"
             :items="holes"
@@ -38,14 +38,14 @@
             :validation="validation.getItem('placement.hole')"
           />
         </v-col>
-        <v-col cols="2">
+        <v-col cols="4" sm="2">
           <v-validate-text-field
             v-model="circlePlacementInput.line"
             :validation="validation.getItem('placement.line')"
             placeholder="A"
           />
         </v-col>
-        <v-col cols="2">
+        <v-col cols="4" sm="2">
           <v-validate-text-field
             v-model.number="circlePlacementInput.number"
             :validation="validation.getItem('placement.number')"
@@ -53,7 +53,7 @@
             placeholder="10"
           />
         </v-col>
-        <v-col cols="2">
+        <v-col cols="4" sm="2">
           <v-validate-select
             v-model="circlePlacementInput.a_or_b"
             :items="aOrB"


### PR DESCRIPTION
resolve: #285 

## この PR で実装される内容
スマホ（xs, < 600px）から見た際に配置に改行が入り、見やすなる

## 確認

-   [x] いい感じになっていること
![image](https://user-images.githubusercontent.com/8841932/175607265-789da10d-c25a-4787-8a33-02559ce96880.png)
![image](https://user-images.githubusercontent.com/8841932/175607300-4beaf601-a92f-47ee-9f9e-11cbe2296356.png)


## 備考
