### PR TITLE
#224 続けて新規サークル登録をできるようにする

### DIFF
--- a/front/components/circle-list/CircleListForm.vue
+++ b/front/components/circle-list/CircleListForm.vue
@@ -166,7 +166,7 @@ export default class CircleListForm extends Vue {
         'edit-circle-product': this.editCircleProduct,
         'want-me-too': this.onWantMeToo,
         'add-circle-product': this.addCircleProduct,
-        'register-new-circle': () => this.$emit('register-new-circle'),
+        'register-new-circle': this.clearForm,
       }
     )
   }

--- a/front/components/circle-list/CircleListForm.vue
+++ b/front/components/circle-list/CircleListForm.vue
@@ -166,6 +166,7 @@ export default class CircleListForm extends Vue {
         'edit-circle-product': this.editCircleProduct,
         'want-me-too': this.onWantMeToo,
         'add-circle-product': this.addCircleProduct,
+        'register-new-circle': () => this.$emit('register-new-circle'),
       }
     )
   }

--- a/front/components/circle-list/form/CircleProducts.vue
+++ b/front/components/circle-list/form/CircleProducts.vue
@@ -10,6 +10,10 @@
       <v-btn color="register" @click="$emit('add-circle-product')">
         頒布物追加
       </v-btn>
+      <v-spacer />
+      <v-btn @click="$emit('register-new-circle')">
+        続けて別のサークルを登録
+      </v-btn>
     </v-card-actions>
   </v-container>
 </template>

--- a/front/components/circle-list/form/states/CircleProductsState.ts
+++ b/front/components/circle-list/form/states/CircleProductsState.ts
@@ -10,6 +10,7 @@ type CircleProductStateEventObservers = {
   'edit-circle-product': (circleProduct: CircleProduct) => void
   'want-me-too': (circleProduct: CircleProduct) => void
   'add-circle-product': () => void
+  'register-new-circle': () => void
 }
 
 export default class CircleProductsState extends AbstractFormState<

--- a/front/pages/teams/_team_id/events/_event_id/circle-list.vue
+++ b/front/pages/teams/_team_id/events/_event_id/circle-list.vue
@@ -38,6 +38,7 @@
         :join-event-id="joinEvent ? joinEvent.id : null"
         :editing-circle-id="editingCircleId"
         @saved="onSavedCircle"
+        @register-new-circle="openCircleListForm(null)"
       />
 
       <v-tabs v-model="selectedCircleListTabIndex" class="mt-5">

--- a/front/pages/teams/_team_id/events/_event_id/circle-list.vue
+++ b/front/pages/teams/_team_id/events/_event_id/circle-list.vue
@@ -38,7 +38,6 @@
         :join-event-id="joinEvent ? joinEvent.id : null"
         :editing-circle-id="editingCircleId"
         @saved="onSavedCircle"
-        @register-new-circle="openCircleListForm(null)"
       />
 
       <v-tabs v-model="selectedCircleListTabIndex" class="mt-5">


### PR DESCRIPTION
resolve: #224 

## この PR で実装される内容
サークルリストモーダルから連続してサークルを登録できるようになる

## 確認

-   [x] 続けて別のサークルを登録をクリックした際に、モーダルが新規登録になること
![f5986395-f8ae-46fe-a766-9f77cd862b8d](https://user-images.githubusercontent.com/8841932/175770373-0991bd8b-ef6e-4394-aa25-41b907183f1c.gif)

## 備考
