### PR TITLE
#283 eslintのwarningでCIが落ちるようにする

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,7 +107,7 @@ jobs:
       # note: CI上でnpm run lintで呼び出した場合（npm script内でnpm scriptを呼ぼうとすると）、243 errorが帰ってきてしまうため、別々に実行している
       - run:
           name: code style check(front - js)
-          command: docker-compose exec front npm run lint:js
+          command: docker-compose exec front npm run lint:js -- --max-warnings 0
           when: always
       - run:
           name: code style check(front - css)


### PR DESCRIPTION
resolve: #283

## この PR で実装される内容
CI上でeslintのwarningが検知された場合、エラーになって落ちるようになる

## 確認

-   [x] warningで落ちること
![image](https://user-images.githubusercontent.com/8841932/175774511-3d2d4622-327c-4df4-bca4-c95d4019cd7f.png)


## 備考
