### PR TITLE
#141 Formの抽象コンポーネントを用意する

### DIFF
--- a/front/components/circle-list/form/CircleForm.vue
+++ b/front/components/circle-list/form/CircleForm.vue
@@ -19,9 +19,9 @@
 <script lang="ts">
 import { Vue, Prop, Component } from 'nuxt-property-decorator'
 import { PropType } from 'vue'
-import { CirclePlacement } from '~/apollo/graphql'
 import CircleRegister from './circle-form/CircleRegister.vue'
 import CircleEditor from './circle-form/CircleEditor.vue'
+import { CirclePlacement } from '~/apollo/graphql'
 
 @Component({
   components: { CircleRegister, CircleEditor },

--- a/front/components/circle-list/form/CircleForm.vue
+++ b/front/components/circle-list/form/CircleForm.vue
@@ -1,155 +1,30 @@
 <template>
-  <validation-observer ref="validationObserver" tag="form">
-    <v-container>
-      <v-row dense>
-        <v-col cols="12">
-          <v-validate-text-field
-            v-model="circleInput.name"
-            :validation="validation.getItem('circle.name')"
-          />
-        </v-col>
-      </v-row>
-
-      <v-row dense>
-        <v-col cols="12">
-          <v-text-field
-            v-model="circleInput.kana"
-            placeholder="サークルの読み方"
-          />
-        </v-col>
-      </v-row>
-
-      <v-row dense>
-        <v-col cols="6" sm="4">
-          <v-validate-select
-            v-model="circlePlacementInput.event_date_id"
-            :items="eventDates"
-            item-text="name"
-            item-value="id"
-            :validation="validation.getItem('placement.event_date_id')"
-          />
-        </v-col>
-        <v-col cols="6" sm="2">
-          <v-validate-select
-            v-model="circlePlacementInput.hole"
-            :items="holes"
-            item-text="name"
-            item-value="name"
-            :validation="validation.getItem('placement.hole')"
-          />
-        </v-col>
-        <v-col cols="4" sm="2">
-          <v-validate-text-field
-            v-model="circlePlacementInput.line"
-            :validation="validation.getItem('placement.line')"
-            placeholder="A"
-          />
-        </v-col>
-        <v-col cols="4" sm="2">
-          <v-validate-text-field
-            v-model.number="circlePlacementInput.number"
-            :validation="validation.getItem('placement.number')"
-            type="number"
-            placeholder="10"
-          />
-        </v-col>
-        <v-col cols="4" sm="2">
-          <v-validate-select
-            v-model="circlePlacementInput.a_or_b"
-            :items="aOrB"
-            item-text="name"
-            item-value="name"
-            :validation="validation.getItem('placement.a_or_b')"
-          />
-        </v-col>
-      </v-row>
-      <v-row dense>
-        <v-col cols="12">
-          <v-validate-select
-            v-model="circlePlacementInput.circle_placement_classification_id"
-            :items="circlePlacementClassifications"
-            item-text="name"
-            item-value="id"
-            :validation="
-              validation.getItem('placement.circle_placement_classification_id')
-            "
-          />
-        </v-col>
-      </v-row>
-
-      <v-row dense>
-        <v-col cols="12">
-          <v-btn color="success" @click="submit">登録</v-btn>
-          <v-btn v-if="circlePlacement" @click="$emit('canceled')">
-            キャンセル
-          </v-btn>
-        </v-col>
-      </v-row>
-    </v-container>
-  </validation-observer>
+  <circle-register
+    v-if="!circlePlacement"
+    :event-id="eventId"
+    :join-event-id="joinEventId"
+    :team-id="teamId"
+    v-on="$listeners"
+  />
+  <circle-editor
+    v-else
+    :event-id="eventId"
+    :join-event-id="joinEventId"
+    :team-id="teamId"
+    :circle-placement="circlePlacement"
+    v-on="$listeners"
+  />
 </template>
 
 <script lang="ts">
-import { Vue, Prop, Component, Watch } from 'nuxt-property-decorator'
+import { Vue, Prop, Component } from 'nuxt-property-decorator'
 import { PropType } from 'vue'
-import { ValidationObserver } from 'vee-validate'
-import { isApolloError } from 'apollo-client/errors/ApolloError'
-import {
-  CreateCircleParticipatingInEventInput,
-  CreateCircleParticipatingInEventMutation,
-  UpdateCircleParticipatingInEventMutation,
-  CreateCareAboutCircleMutation,
-  CircleInput,
-  CirclePlacementInput,
-  EventDate,
-  EventWithDateQuery,
-  CirclePlacement,
-  CirclePlacementClassification,
-  CirclePlacementClassificationsQuery,
-  CareAboutCircleInput,
-} from '~/apollo/graphql'
-import { CreateCircleParticipatingInEventInputValidation } from '~/validation/validations'
-
-// TODO: ほかでも使うようならモジュール化、ちゃんと理解する
-//       https://qiita.com/mizchi/items/5c359fb5b5e921a7d55f
-type Draft<T, D extends keyof T> = {
-  [K in keyof T]: K extends D ? T[K] | null : T[K]
-}
-
-type DraftCirclePlacementInput = Draft<CirclePlacementInput, 'number'>
-
-const initialCirclePlacementInput: DraftCirclePlacementInput = {
-  event_date_id: '',
-  hole: '東',
-  line: '',
-  number: null,
-  a_or_b: 'a',
-  circle_placement_classification_id: '',
-}
-
-const initialCircleInput: CircleInput = {
-  name: '',
-  kana: '',
-}
+import { CirclePlacement } from '~/apollo/graphql'
+import CircleRegister from './circle-form/CircleRegister.vue'
+import CircleEditor from './circle-form/CircleEditor.vue'
 
 @Component({
-  apollo: {
-    eventDates: {
-      query: EventWithDateQuery,
-      variables() {
-        return { id: this.eventId }
-      },
-      update(data) {
-        return data.event.eventDates
-      },
-    },
-    circlePlacementClassifications: {
-      query: CirclePlacementClassificationsQuery,
-      variables() {
-        return { teamId: this.teamId }
-      },
-    },
-  },
+  components: { CircleRegister, CircleEditor },
 })
 export default class CircleForm extends Vue {
   @Prop({ type: String, required: true })
@@ -162,137 +37,6 @@ export default class CircleForm extends Vue {
   private joinEventId!: string
 
   @Prop({ type: Object as PropType<CirclePlacement> })
-  private circlePlacement?: CirclePlacement
-
-  private validation: CreateCircleParticipatingInEventInputValidation =
-    new CreateCircleParticipatingInEventInputValidation()
-
-  private circleInput: CircleInput = { ...initialCircleInput }
-
-  private circlePlacementInput: DraftCirclePlacementInput = {
-    ...initialCirclePlacementInput,
-  }
-
-  private eventDates: EventDate[] = []
-
-  // TODO: イベントごとにホールのマスタを変更できるようにする？
-  private holes: { name: string }[] = [
-    { name: '東' },
-    { name: '西' },
-    { name: '南' },
-  ]
-
-  private aOrB: { name: string }[] = [{ name: 'a' }, { name: 'b' }]
-
-  private circlePlacementClassifications: CirclePlacementClassification[] = []
-
-  $refs!: {
-    validationObserver: InstanceType<typeof ValidationObserver>
-  }
-
-  @Watch('circlePlacement', { immediate: true })
-  private onUpdateCirclePlacement(): void {
-    if (!this.circlePlacement) {
-      this.circlePlacementInput = { ...initialCirclePlacementInput }
-      this.circleInput = { ...initialCircleInput }
-      return
-    }
-    const circlePlacementInput = {}
-    Object.keys(initialCirclePlacementInput).forEach((key) => {
-      ;(circlePlacementInput as any)[key] = (this.circlePlacement as any)[key]
-    })
-    this.circlePlacementInput = circlePlacementInput as CirclePlacementInput
-    const circleInput = {}
-    Object.keys(initialCircleInput).forEach((key) => {
-      ;(circleInput as any)[key] = (this.circlePlacement?.circle as any)[key]
-    })
-    this.circleInput = circleInput as CircleInput
-  }
-
-  private async submit() {
-    const observer = this.$refs.validationObserver
-    const isValid = await observer.validate()
-    if (isValid) {
-      const postMethod: Function = this.circlePlacement?.circle?.id
-        ? this.updateCircle
-        : this.createCircle
-      const circle = await postMethod()
-
-      if (!circle) {
-        return
-      }
-
-      this.$toast.success('保存しました')
-      this.$emit('saved', { circle })
-    }
-  }
-
-  private async createCircle() {
-    const input: CreateCircleParticipatingInEventInput = {
-      circle: this.circleInput,
-      placement: this.circlePlacementInput as CirclePlacementInput,
-    }
-
-    const circlePlacement = await this.$apollo
-      .mutate({
-        mutation: CreateCircleParticipatingInEventMutation,
-        variables: { input },
-      })
-      .then((res) => res.data.createCircleParticipatingInEvent)
-      .catch((error) => {
-        if (isApolloError(error)) {
-          this.$toasted.global.validationError()
-          this.validation.setBackendErrorsFromAppolo(error)
-        }
-      })
-
-    const careAboutCircleInput: CareAboutCircleInput = {
-      join_event_id: this.joinEventId,
-      circle_placement_id: circlePlacement.id,
-    }
-    await this.$apollo
-      .mutate({
-        mutation: CreateCareAboutCircleMutation,
-        variables: { input: careAboutCircleInput },
-      })
-      .then((res) => res.data.createCareAboutCircle)
-      .catch((error) => {
-        if (isApolloError(error)) {
-          this.$toasted.global.validationError()
-          this.validation.setBackendErrorsFromAppolo(error)
-        }
-      })
-    return circlePlacement.circle
-  }
-
-  private async updateCircle() {
-    const input: CreateCircleParticipatingInEventInput = {
-      circle: this.circleInput,
-      placement: this.circlePlacementInput as CirclePlacementInput,
-    }
-
-    const id = this.circlePlacement!.circle!.id
-
-    return await this.$apollo
-      .mutate({
-        mutation: UpdateCircleParticipatingInEventMutation,
-        variables: { id, input },
-      })
-      .then((res) => {
-        return res.data.updateCircleParticipatingInEvent.circle
-      })
-      .catch((error) => {
-        if (isApolloError(error)) {
-          const errorExtensions = error.graphQLErrors[0].extensions
-          if (errorExtensions.category === 'updateDenied') {
-            this.$toast.error(errorExtensions.message)
-            return
-          }
-
-          this.$toasted.global.validationError()
-          this.validation.setBackendErrorsFromAppolo(error)
-        }
-      })
-  }
+  private circlePlacement!: CirclePlacement | null
 }
 </script>

--- a/front/components/circle-list/form/WantMeTooForm.vue
+++ b/front/components/circle-list/form/WantMeTooForm.vue
@@ -17,7 +17,7 @@
 </template>
 
 <script lang="ts">
-import { Vue, Prop, Component, Watch } from 'nuxt-property-decorator'
+import { Prop, Component, Watch } from 'nuxt-property-decorator'
 import { PropType } from 'vue'
 import WantMeTooFormInput from './want-me-to-form/WantMeToFormInput.vue'
 import AbstractForm from '~/components/form/AbstractForm.vue'

--- a/front/components/circle-list/form/WantMeTooForm.vue
+++ b/front/components/circle-list/form/WantMeTooForm.vue
@@ -1,54 +1,30 @@
 <template>
   <validation-observer ref="validationObserver" tag="form">
-    <v-container>
-      <v-row dense>
-        <v-col cols="12">
-          {{ circleProduct.name }}
-        </v-col>
-      </v-row>
+    <want-me-too-form-input
+      v-model="input"
+      :validation="validation"
+      :team-id="teamId"
+      :circle-product="circleProduct"
+    />
 
-      <v-row dense>
-        <v-col cols="12">
-          <v-validate-text-field
-            v-model="input.quantity"
-            type="number"
-            :validation="validation.getItem('quantity')"
-          />
-        </v-col>
-      </v-row>
-
-      <v-row dense>
-        <v-col cols="12">
-          <v-validate-select
-            v-model="input.want_priority_id"
-            :items="wantPriorities"
-            item-text="name"
-            item-value="id"
-            :validation="validation.getItem('want_priority_id')"
-          />
-        </v-col>
-      </v-row>
-
-      <v-row dense>
-        <v-col cols="12">
-          <v-btn color="success" @click="submit">登録</v-btn>
-          <v-btn @click="$emit('canceled')">キャンセル</v-btn>
-        </v-col>
-      </v-row>
-    </v-container>
+    <v-row dense>
+      <v-col cols="12">
+        <v-btn color="success" @click="submit">登録</v-btn>
+        <v-btn @click="$emit('canceled')">キャンセル</v-btn>
+      </v-col>
+    </v-row>
   </validation-observer>
 </template>
 
 <script lang="ts">
 import { Vue, Prop, Component, Watch } from 'nuxt-property-decorator'
 import { PropType } from 'vue'
-import { ValidationObserver } from 'vee-validate'
-import { isApolloError } from 'apollo-client/errors/ApolloError'
+import WantMeTooFormInput from './want-me-to-form/WantMeToFormInput.vue'
+import AbstractForm from '~/components/form/AbstractForm.vue'
 import {
   CircleProduct,
+  WantCircleProduct,
   WantCircleProductInput,
-  WantPrioritiesQuery,
-  WantPriority,
   WantMeTooCircleProductMutation,
 } from '~/apollo/graphql'
 import { CreateWantCircleProductInputValidation } from '~/validation/validations'
@@ -59,23 +35,15 @@ const initialWantCircleProductInput: WantCircleProductInput = {
 }
 
 @Component({
-  apollo: {
-    wantPriorities: {
-      query: WantPrioritiesQuery,
-      variables() {
-        const teamId = this.teamId
-        return { teamId }
-      },
-    },
+  components: {
+    WantMeTooFormInput,
   },
 })
-export default class WantMeTooForm extends Vue {
-  private validation: CreateWantCircleProductInputValidation =
+export default class WantMeTooForm extends AbstractForm<CreateWantCircleProductInputValidation> {
+  protected validation: CreateWantCircleProductInputValidation =
     new CreateWantCircleProductInputValidation()
 
   private input: WantCircleProductInput = { ...initialWantCircleProductInput }
-
-  private wantPriorities: WantPriority[] = []
 
   @Prop({ type: String, required: true })
   private teamId!: string
@@ -91,37 +59,23 @@ export default class WantMeTooForm extends Vue {
     this.input = { ...initialWantCircleProductInput }
   }
 
-  $refs!: {
-    validationObserver: InstanceType<typeof ValidationObserver>
+  protected async mutate(): Promise<any> {
+    const variables = {
+      input: {
+        ...this.input,
+        join_event_id: this.joinEventId,
+        circle_product_id: this.circleProduct.id,
+      },
+    }
+
+    return await this.$apollo.mutate({
+      mutation: WantMeTooCircleProductMutation,
+      variables,
+    })
   }
 
-  private async submit() {
-    const observer = this.$refs.validationObserver
-    const isValid = await observer.validate()
-    if (isValid) {
-      const variables = {
-        input: {
-          ...this.input,
-          join_event_id: this.joinEventId,
-          circle_product_id: this.circleProduct.id,
-        },
-      }
-
-      try {
-        const wantCircleProduct = await this.$apollo.mutate({
-          mutation: WantMeTooCircleProductMutation,
-          variables,
-        })
-
-        this.$toast.success('保存しました')
-        this.$emit('saved', { wantCircleProduct })
-      } catch (error: any) {
-        if (isApolloError(error)) {
-          this.$toasted.global.validationError()
-          this.validation.setBackendErrorsFromAppolo(error)
-        }
-      }
-    }
+  protected afterMutate(wantCircleProduct: WantCircleProduct): void {
+    this.$emit('saved', { wantCircleProduct })
   }
 }
 </script>

--- a/front/components/circle-list/form/circle-form/CircleEditor.vue
+++ b/front/components/circle-list/form/circle-form/CircleEditor.vue
@@ -96,7 +96,7 @@ export default class CircleEditor extends AbstractForm<CreateCircleParticipating
       })
   }
 
-  protected async afterMutate(circle: Circle) {
+  protected afterMutate(circle: Circle) {
     this.$emit('saved', { circle })
   }
 

--- a/front/components/circle-list/form/circle-form/CircleEditor.vue
+++ b/front/components/circle-list/form/circle-form/CircleEditor.vue
@@ -1,0 +1,145 @@
+<template>
+  <validation-observer ref="validationObserver" tag="form">
+    <circle-form-input :input.sync="circleInput" :validation="validation" />
+    <circle-placement-form-input
+      :input.sync="circlePlacementInput"
+      :validation="validation"
+      :event-id="eventId"
+      :team-id="teamId"
+    />
+    <v-container>
+      <v-row dense>
+        <v-col cols="12">
+          <v-btn color="success" @click="submit">登録</v-btn>
+          <v-btn @click="$emit('canceled')">キャンセル</v-btn>
+        </v-col>
+      </v-row>
+    </v-container>
+  </validation-observer>
+</template>
+
+<script lang="ts">
+import { Vue, Prop, Component, Watch } from 'nuxt-property-decorator'
+import { PropType } from 'vue'
+import { ValidationObserver } from 'vee-validate'
+import { isApolloError } from 'apollo-client/errors/ApolloError'
+import CirclePlacementForm, {
+  DraftCirclePlacementInput,
+} from './CirclePlacementFormInput.vue'
+import {
+  CreateCircleParticipatingInEventInput,
+  UpdateCircleParticipatingInEventMutation,
+  CircleInput,
+  CirclePlacementInput,
+  CirclePlacement,
+} from '~/apollo/graphql'
+import { CreateCircleParticipatingInEventInputValidation } from '~/validation/validations'
+
+const initialCirclePlacementInput: DraftCirclePlacementInput = {
+  event_date_id: '',
+  hole: '東',
+  line: '',
+  number: null,
+  a_or_b: 'a',
+  circle_placement_classification_id: '',
+}
+
+const initialCircleInput: CircleInput = {
+  name: '',
+  kana: '',
+}
+
+@Component({
+  components: { CircleForm, CirclePlacementForm },
+})
+export default class CircleForm extends Vue {
+  @Prop({ type: String, required: true })
+  private eventId!: String
+
+  @Prop({ type: String, required: true })
+  private teamId!: String
+
+  @Prop({ type: String })
+  private joinEventId!: string
+
+  @Prop({ type: Object as PropType<CirclePlacement>, required: true })
+  private circlePlacement!: CirclePlacement
+
+  private validation: CreateCircleParticipatingInEventInputValidation =
+    new CreateCircleParticipatingInEventInputValidation()
+
+  private circleInput: CircleInput = { ...initialCircleInput }
+
+  private circlePlacementInput: DraftCirclePlacementInput = {
+    ...initialCirclePlacementInput,
+  }
+
+  $refs!: {
+    validationObserver: InstanceType<typeof ValidationObserver>
+  }
+
+  @Watch('circlePlacement', { immediate: true })
+  private onUpdateCirclePlacement(): void {
+    if (!this.circlePlacement) {
+      this.circlePlacementInput = { ...initialCirclePlacementInput }
+      this.circleInput = { ...initialCircleInput }
+      return
+    }
+    const circlePlacementInput = {}
+    Object.keys(initialCirclePlacementInput).forEach((key) => {
+      ;(circlePlacementInput as any)[key] = (this.circlePlacement as any)[key]
+    })
+    this.circlePlacementInput = circlePlacementInput as CirclePlacementInput
+    const circleInput = {}
+    Object.keys(initialCircleInput).forEach((key) => {
+      ;(circleInput as any)[key] = (this.circlePlacement?.circle as any)[key]
+    })
+    this.circleInput = circleInput as CircleInput
+  }
+
+  private async submit() {
+    const observer = this.$refs.validationObserver
+    const isValid = await observer.validate()
+    if (isValid) {
+      const circle = await this.updateCircle()
+
+      if (!circle) {
+        return
+      }
+
+      this.$toast.success('保存しました')
+      this.$emit('saved', { circle })
+    }
+  }
+
+  private async updateCircle() {
+    const input: CreateCircleParticipatingInEventInput = {
+      circle: this.circleInput,
+      placement: this.circlePlacementInput as CirclePlacementInput,
+    }
+
+    const id = this.circlePlacement!.circle!.id
+
+    return await this.$apollo
+      .mutate({
+        mutation: UpdateCircleParticipatingInEventMutation,
+        variables: { id, input },
+      })
+      .then((res) => {
+        return res.data.updateCircleParticipatingInEvent.circle
+      })
+      .catch((error) => {
+        if (isApolloError(error)) {
+          const errorExtensions = error.graphQLErrors[0].extensions
+          if (errorExtensions.category === 'updateDenied') {
+            this.$toast.error(errorExtensions.message)
+            return
+          }
+
+          this.$toasted.global.validationError()
+          this.validation.setBackendErrorsFromAppolo(error)
+        }
+      })
+  }
+}
+</script>

--- a/front/components/circle-list/form/circle-form/CircleEditor.vue
+++ b/front/components/circle-list/form/circle-form/CircleEditor.vue
@@ -1,8 +1,8 @@
 <template>
   <validation-observer ref="validationObserver" tag="form">
-    <circle-form-input :input.sync="circleInput" :validation="validation" />
+    <circle-form-input v-model="circleInput" :validation="validation" />
     <circle-placement-form-input
-      :input.sync="circlePlacementInput"
+      v-model="circlePlacementInput"
       :validation="validation"
       :event-id="eventId"
       :team-id="teamId"

--- a/front/components/circle-list/form/circle-form/CircleFormInput.vue
+++ b/front/components/circle-list/form/circle-form/CircleFormInput.vue
@@ -3,7 +3,7 @@
     <v-row dense>
       <v-col cols="12">
         <v-validate-text-field
-          v-model="circleInput.name"
+          v-model="input.name"
           :validation="validation.getItem('circle.name')"
         />
       </v-col>
@@ -11,32 +11,21 @@
 
     <v-row dense>
       <v-col cols="12">
-        <v-text-field
-          v-model="circleInput.kana"
-          placeholder="サークルの読み方"
-        />
+        <v-text-field v-model="input.kana" placeholder="サークルの読み方" />
       </v-col>
     </v-row>
   </v-container>
 </template>
 
 <script lang="ts">
-import { Vue, PropSync, Component, Prop } from 'nuxt-property-decorator'
-import { PropType } from 'vue'
-import { CircleInput, CirclePlacement } from '~/apollo/graphql'
+import { Component } from 'nuxt-property-decorator'
+import AbstractFormInput from '~/components/form/AbstractFormInput.vue'
+import { CircleInput } from '~/apollo/graphql'
 import { CreateCircleParticipatingInEventInputValidation } from '~/validation/validations'
 
 @Component({})
-export default class CircleFormInput extends Vue {
-  @Prop({
-    type: Object as PropType<CreateCircleParticipatingInEventInputValidation>,
-  })
-  private validation!: CreateCircleParticipatingInEventInputValidation
-
-  @PropSync('input', {
-    type: Object as PropType<CirclePlacement>,
-    required: true,
-  })
-  private circleInput!: CircleInput
-}
+export default class CircleFormInput extends AbstractFormInput<
+  CircleInput,
+  CreateCircleParticipatingInEventInputValidation
+> {}
 </script>

--- a/front/components/circle-list/form/circle-form/CircleFormInput.vue
+++ b/front/components/circle-list/form/circle-form/CircleFormInput.vue
@@ -1,0 +1,42 @@
+<template>
+  <v-container>
+    <v-row dense>
+      <v-col cols="12">
+        <v-validate-text-field
+          v-model="circleInput.name"
+          :validation="validation.getItem('circle.name')"
+        />
+      </v-col>
+    </v-row>
+
+    <v-row dense>
+      <v-col cols="12">
+        <v-text-field
+          v-model="circleInput.kana"
+          placeholder="サークルの読み方"
+        />
+      </v-col>
+    </v-row>
+  </v-container>
+</template>
+
+<script lang="ts">
+import { Vue, PropSync, Component, Prop } from 'nuxt-property-decorator'
+import { PropType } from 'vue'
+import { CircleInput, CirclePlacement } from '~/apollo/graphql'
+import { CreateCircleParticipatingInEventInputValidation } from '~/validation/validations'
+
+@Component({})
+export default class CircleFormInput extends Vue {
+  @Prop({
+    type: Object as PropType<CreateCircleParticipatingInEventInputValidation>,
+  })
+  private validation!: CreateCircleParticipatingInEventInputValidation
+
+  @PropSync('input', {
+    type: Object as PropType<CirclePlacement>,
+    required: true,
+  })
+  private circleInput!: CircleInput
+}
+</script>

--- a/front/components/circle-list/form/circle-form/CirclePlacementFormInput.vue
+++ b/front/components/circle-list/form/circle-form/CirclePlacementFormInput.vue
@@ -1,0 +1,134 @@
+<template>
+  <v-container>
+    <v-row dense>
+      <v-col cols="6" sm="4">
+        <v-validate-select
+          v-model="circlePlacementInput.event_date_id"
+          :items="eventDates"
+          item-text="name"
+          item-value="id"
+          :validation="validation.getItem('placement.event_date_id')"
+        />
+      </v-col>
+      <v-col cols="6" sm="2">
+        <v-validate-select
+          v-model="circlePlacementInput.hole"
+          :items="holes"
+          item-text="name"
+          item-value="name"
+          :validation="validation.getItem('placement.hole')"
+        />
+      </v-col>
+      <v-col cols="4" sm="2">
+        <v-validate-text-field
+          v-model="circlePlacementInput.line"
+          :validation="validation.getItem('placement.line')"
+          placeholder="A"
+        />
+      </v-col>
+      <v-col cols="4" sm="2">
+        <v-validate-text-field
+          v-model.number="circlePlacementInput.number"
+          :validation="validation.getItem('placement.number')"
+          type="number"
+          placeholder="10"
+        />
+      </v-col>
+      <v-col cols="4" sm="2">
+        <v-validate-select
+          v-model="circlePlacementInput.a_or_b"
+          :items="aOrB"
+          item-text="name"
+          item-value="name"
+          :validation="validation.getItem('placement.a_or_b')"
+        />
+      </v-col>
+    </v-row>
+    <v-row dense>
+      <v-col cols="12">
+        <v-validate-select
+          v-model="circlePlacementInput.circle_placement_classification_id"
+          :items="circlePlacementClassifications"
+          item-text="name"
+          item-value="id"
+          :validation="
+            validation.getItem('placement.circle_placement_classification_id')
+          "
+        />
+      </v-col>
+    </v-row>
+  </v-container>
+</template>
+
+<script lang="ts">
+import { Vue, Prop, PropSync, Component } from 'nuxt-property-decorator'
+import { PropType } from 'vue'
+import {
+  CirclePlacementInput,
+  EventDate,
+  EventWithDateQuery,
+  CirclePlacement,
+  CirclePlacementClassification,
+  CirclePlacementClassificationsQuery,
+} from '~/apollo/graphql'
+import { CreateCircleParticipatingInEventInputValidation } from '~/validation/validations'
+
+// TODO: ほかでも使うようならモジュール化、ちゃんと理解する
+//       https://qiita.com/mizchi/items/5c359fb5b5e921a7d55f
+type Draft<T, D extends keyof T> = {
+  [K in keyof T]: K extends D ? T[K] | null : T[K]
+}
+
+export type DraftCirclePlacementInput = Draft<CirclePlacementInput, 'number'>
+
+@Component({
+  apollo: {
+    eventDates: {
+      query: EventWithDateQuery,
+      variables() {
+        return { id: this.eventId }
+      },
+      update(data) {
+        return data.event.eventDates
+      },
+    },
+    circlePlacementClassifications: {
+      query: CirclePlacementClassificationsQuery,
+      variables() {
+        return { teamId: this.teamId }
+      },
+    },
+  },
+})
+export default class CirclePlacementFormInput extends Vue {
+  @Prop({ type: String, required: true })
+  private eventId!: String
+
+  @Prop({ type: String, required: true })
+  private teamId!: String
+
+  @Prop({
+    type: Object as PropType<CreateCircleParticipatingInEventInputValidation>,
+  })
+  private validation!: CreateCircleParticipatingInEventInputValidation
+
+  @PropSync('input', {
+    type: Object as PropType<CirclePlacement>,
+    required: true,
+  })
+  private circlePlacementInput!: DraftCirclePlacementInput
+
+  private eventDates: EventDate[] = []
+
+  // TODO: イベントごとにホールのマスタを変更できるようにする？
+  private holes: { name: string }[] = [
+    { name: '東' },
+    { name: '西' },
+    { name: '南' },
+  ]
+
+  private aOrB: { name: string }[] = [{ name: 'a' }, { name: 'b' }]
+
+  private circlePlacementClassifications: CirclePlacementClassification[] = []
+}
+</script>

--- a/front/components/circle-list/form/circle-form/CirclePlacementFormInput.vue
+++ b/front/components/circle-list/form/circle-form/CirclePlacementFormInput.vue
@@ -3,7 +3,7 @@
     <v-row dense>
       <v-col cols="6" sm="4">
         <v-validate-select
-          v-model="circlePlacementInput.event_date_id"
+          v-model="input.event_date_id"
           :items="eventDates"
           item-text="name"
           item-value="id"
@@ -12,7 +12,7 @@
       </v-col>
       <v-col cols="6" sm="2">
         <v-validate-select
-          v-model="circlePlacementInput.hole"
+          v-model="input.hole"
           :items="holes"
           item-text="name"
           item-value="name"
@@ -21,14 +21,14 @@
       </v-col>
       <v-col cols="4" sm="2">
         <v-validate-text-field
-          v-model="circlePlacementInput.line"
+          v-model="input.line"
           :validation="validation.getItem('placement.line')"
           placeholder="A"
         />
       </v-col>
       <v-col cols="4" sm="2">
         <v-validate-text-field
-          v-model.number="circlePlacementInput.number"
+          v-model.number="input.number"
           :validation="validation.getItem('placement.number')"
           type="number"
           placeholder="10"
@@ -36,7 +36,7 @@
       </v-col>
       <v-col cols="4" sm="2">
         <v-validate-select
-          v-model="circlePlacementInput.a_or_b"
+          v-model="input.a_or_b"
           :items="aOrB"
           item-text="name"
           item-value="name"
@@ -47,7 +47,7 @@
     <v-row dense>
       <v-col cols="12">
         <v-validate-select
-          v-model="circlePlacementInput.circle_placement_classification_id"
+          v-model="input.circle_placement_classification_id"
           :items="circlePlacementClassifications"
           item-text="name"
           item-value="id"
@@ -61,13 +61,12 @@
 </template>
 
 <script lang="ts">
-import { Vue, Prop, PropSync, Component } from 'nuxt-property-decorator'
-import { PropType } from 'vue'
+import { Prop, Component } from 'nuxt-property-decorator'
+import AbstractFormInput from '~/components/form/AbstractFormInput.vue'
 import {
   CirclePlacementInput,
   EventDate,
   EventWithDateQuery,
-  CirclePlacement,
   CirclePlacementClassification,
   CirclePlacementClassificationsQuery,
 } from '~/apollo/graphql'
@@ -100,23 +99,15 @@ export type DraftCirclePlacementInput = Draft<CirclePlacementInput, 'number'>
     },
   },
 })
-export default class CirclePlacementFormInput extends Vue {
+export default class CirclePlacementFormInput extends AbstractFormInput<
+  DraftCirclePlacementInput,
+  CreateCircleParticipatingInEventInputValidation
+> {
   @Prop({ type: String, required: true })
   private eventId!: String
 
   @Prop({ type: String, required: true })
   private teamId!: String
-
-  @Prop({
-    type: Object as PropType<CreateCircleParticipatingInEventInputValidation>,
-  })
-  private validation!: CreateCircleParticipatingInEventInputValidation
-
-  @PropSync('input', {
-    type: Object as PropType<CirclePlacement>,
-    required: true,
-  })
-  private circlePlacementInput!: DraftCirclePlacementInput
 
   private eventDates: EventDate[] = []
 

--- a/front/components/circle-list/form/circle-form/CircleRegister.vue
+++ b/front/components/circle-list/form/circle-form/CircleRegister.vue
@@ -1,0 +1,131 @@
+<template>
+  <validation-observer ref="validationObserver" tag="form">
+    <circle-form-input :input.sync="circleInput" :validation="validation" />
+    <circle-placement-form-input
+      :input.sync="circlePlacementInput"
+      :validation="validation"
+      :event-id="eventId"
+      :team-id="teamId"
+    />
+    <v-container>
+      <v-row dense>
+        <v-col cols="12">
+          <v-btn color="success" @click="submit">登録</v-btn>
+        </v-col>
+      </v-row>
+    </v-container>
+  </validation-observer>
+</template>
+
+<script lang="ts">
+import { Vue, Prop, Component } from 'nuxt-property-decorator'
+import { ValidationObserver } from 'vee-validate'
+import { isApolloError } from 'apollo-client/errors/ApolloError'
+import CircleForm from './CircleFormInput.vue'
+import CirclePlacementForm, {
+  DraftCirclePlacementInput,
+} from './CirclePlacementFormInput.vue'
+import {
+  CreateCircleParticipatingInEventInput,
+  CreateCircleParticipatingInEventMutation,
+  CreateCareAboutCircleMutation,
+  CircleInput,
+  CirclePlacementInput,
+  CareAboutCircleInput,
+} from '~/apollo/graphql'
+import { CreateCircleParticipatingInEventInputValidation } from '~/validation/validations'
+
+const initialCirclePlacementInput: DraftCirclePlacementInput = {
+  event_date_id: '',
+  hole: '東',
+  line: '',
+  number: null,
+  a_or_b: 'a',
+  circle_placement_classification_id: '',
+}
+
+const initialCircleInput: CircleInput = {
+  name: '',
+  kana: '',
+}
+
+@Component({
+  components: { CircleForm, CirclePlacementForm },
+})
+export default class CircleRegister extends Vue {
+  @Prop({ type: String, required: true })
+  private eventId!: String
+
+  @Prop({ type: String, required: true })
+  private teamId!: String
+
+  @Prop({ type: String })
+  private joinEventId!: string
+
+  private validation: CreateCircleParticipatingInEventInputValidation =
+    new CreateCircleParticipatingInEventInputValidation()
+
+  private circleInput: CircleInput = { ...initialCircleInput }
+
+  private circlePlacementInput: DraftCirclePlacementInput = {
+    ...initialCirclePlacementInput,
+  }
+
+  $refs!: {
+    validationObserver: InstanceType<typeof ValidationObserver>
+  }
+
+  private async submit() {
+    const observer = this.$refs.validationObserver
+    const isValid = await observer.validate()
+    if (isValid) {
+      const circle = await this.createCircle()
+
+      if (!circle) {
+        return
+      }
+
+      this.$toast.success('保存しました')
+      this.$emit('saved', { circle })
+    }
+  }
+
+  private async createCircle() {
+    const input: CreateCircleParticipatingInEventInput = {
+      circle: this.circleInput,
+      placement: this.circlePlacementInput as CirclePlacementInput,
+    }
+
+    const circlePlacement = await this.$apollo
+      .mutate({
+        mutation: CreateCircleParticipatingInEventMutation,
+        variables: { input },
+      })
+      .then((res) => res.data.createCircleParticipatingInEvent)
+      .catch((error) => {
+        if (isApolloError(error)) {
+          this.$toasted.global.validationError()
+          this.validation.setBackendErrorsFromAppolo(error)
+        }
+      })
+
+    const careAboutCircleInput: CareAboutCircleInput = {
+      join_event_id: this.joinEventId,
+      circle_placement_id: circlePlacement.id,
+    }
+    await this.$apollo
+      .mutate({
+        mutation: CreateCareAboutCircleMutation,
+        variables: { input: careAboutCircleInput },
+      })
+      .then((res) => res.data.createCareAboutCircle)
+      .catch((error) => {
+        if (isApolloError(error)) {
+          this.$toasted.global.validationError()
+          this.validation.setBackendErrorsFromAppolo(error)
+        }
+      })
+    return circlePlacement.circle
+  }
+}
+</script>

--- a/front/components/circle-list/form/circle-form/CircleRegister.vue
+++ b/front/components/circle-list/form/circle-form/CircleRegister.vue
@@ -1,8 +1,8 @@
 <template>
   <validation-observer ref="validationObserver" tag="form">
-    <circle-form-input :input.sync="circleInput" :validation="validation" />
+    <circle-form-input v-model="circleInput" :validation="validation" />
     <circle-placement-form-input
-      :input.sync="circlePlacementInput"
+      v-model="circlePlacementInput"
       :validation="validation"
       :event-id="eventId"
       :team-id="teamId"

--- a/front/components/circle-list/form/want-me-to-form/WantMeToFormInput.vue
+++ b/front/components/circle-list/form/want-me-to-form/WantMeToFormInput.vue
@@ -1,0 +1,68 @@
+<template>
+  <v-container>
+    <v-row dense>
+      <v-col cols="12">
+        {{ circleProduct.name }}
+      </v-col>
+    </v-row>
+
+    <v-row dense>
+      <v-col cols="12">
+        <v-validate-text-field
+          v-model="input.quantity"
+          type="number"
+          :validation="validation.getItem('quantity')"
+        />
+      </v-col>
+    </v-row>
+
+    <v-row dense>
+      <v-col cols="12">
+        <v-validate-select
+          v-model="input.want_priority_id"
+          :items="wantPriorities"
+          item-text="name"
+          item-value="id"
+          :validation="validation.getItem('want_priority_id')"
+        />
+      </v-col>
+    </v-row>
+  </v-container>
+</template>
+
+<script lang="ts">
+import { PropType } from 'vue'
+import { Component, Prop } from 'nuxt-property-decorator'
+import AbstractFormInput from '~/components/form/AbstractFormInput.vue'
+import {
+  CircleProduct,
+  WantCircleProductInput,
+  WantPrioritiesQuery,
+  WantPriority,
+} from '~/apollo/graphql'
+import { CreateWantCircleProductInputValidation } from '~/validation/validations'
+
+@Component({
+  apollo: {
+    wantPriorities: {
+      query: WantPrioritiesQuery,
+      variables() {
+        const teamId = this.teamId
+        return { teamId }
+      },
+    },
+  },
+})
+export default class WantMeTooFormInput extends AbstractFormInput<
+  WantCircleProductInput,
+  CreateWantCircleProductInputValidation
+> {
+  @Prop({ type: String, required: true })
+  private teamId!: string
+
+  @Prop({ type: Object as PropType<CircleProduct>, required: true })
+  private circleProduct!: string
+
+  private wantPriorities: WantPriority[] = []
+}
+</script>

--- a/front/components/form/AbstractForm.vue
+++ b/front/components/form/AbstractForm.vue
@@ -1,11 +1,8 @@
 <script lang="ts">
-import { Vue, Prop, Component, Watch } from 'nuxt-property-decorator'
-import { PropType, PropOptions } from 'vue'
-import BaseValidation from '~/validation/validation'
+import { Vue, Component } from 'nuxt-property-decorator'
 import { ValidationObserver } from 'vee-validate'
 import { isApolloError } from 'apollo-client/errors/ApolloError'
-import Validation from '~/validation/validation'
-import { CreateCircleParticipatingInEventInputValidation } from '~/validation/validations'
+import BaseValidation from '~/validation/validation'
 
 // @ts-ignore
 @Component({
@@ -20,7 +17,9 @@ export default abstract class AbstractForm<
   protected abstract mutate(): Promise<any>
 
   // note: 必要に応じてオーバーライドして使う
-  protected afterMutate(data: any) {}
+  protected afterMutate(data: any) {
+    return data
+  }
 
   protected migrateModelToInput(input: any, model: any): any {
     const workInput: any = {}

--- a/front/components/form/AbstractForm.vue
+++ b/front/components/form/AbstractForm.vue
@@ -1,0 +1,15 @@
+<script lang="ts">
+import { Vue, Prop, Component } from 'nuxt-property-decorator'
+import { PropType, PropOptions } from 'vue'
+import BaseValidation from '~/validation/validation'
+
+// @ts-ignore
+@Component({
+  inheritAttrs: false,
+})
+export default abstract class AbstractForm<
+  Validation extends BaseValidation | null
+> extends Vue {
+  protected abstract validation: Validation
+}
+</script>

--- a/front/components/form/AbstractForm.vue
+++ b/front/components/form/AbstractForm.vue
@@ -1,7 +1,11 @@
 <script lang="ts">
-import { Vue, Prop, Component } from 'nuxt-property-decorator'
+import { Vue, Prop, Component, Watch } from 'nuxt-property-decorator'
 import { PropType, PropOptions } from 'vue'
 import BaseValidation from '~/validation/validation'
+import { ValidationObserver } from 'vee-validate'
+import { isApolloError } from 'apollo-client/errors/ApolloError'
+import Validation from '~/validation/validation'
+import { CreateCircleParticipatingInEventInputValidation } from '~/validation/validations'
 
 // @ts-ignore
 @Component({
@@ -10,6 +14,49 @@ import BaseValidation from '~/validation/validation'
 export default abstract class AbstractForm<
   Validation extends BaseValidation | null
 > extends Vue {
-  protected abstract validation: Validation
+  protected abstract validation: Validation | null
+
+  // return $apollo.mutate() のようなミューテーションの実態を定義するメソッド
+  protected abstract mutate(): Promise<any>
+
+  // note: 必要に応じてオーバーライドして使う
+  protected afterMutate(data: any) {}
+
+  protected migrateModelToInput(input: any, model: any): any {
+    const workInput: any = {}
+    Object.keys(input).forEach((key) => {
+      workInput[key] = model[key]
+    })
+    return workInput
+  }
+
+  $refs!: {
+    validationObserver: InstanceType<typeof ValidationObserver>
+  }
+
+  protected async submit(): Promise<void> {
+    const observer = this.$refs.validationObserver
+    const isValid = await observer.validate()
+    if (isValid) {
+      try {
+        const data = await this.mutate()
+
+        this.afterMutate(data)
+
+        this.$toast.success('保存しました')
+      } catch (error: any) {
+        this.handleError(error)
+      }
+    }
+  }
+
+  protected handleError(error: any): void {
+    if (isApolloError(error)) {
+      this.$toasted.global.validationError()
+      if (this.validation) {
+        this.validation.setBackendErrorsFromAppolo(error)
+      }
+    }
+  }
 }
 </script>

--- a/front/components/form/AbstractFormInput.vue
+++ b/front/components/form/AbstractFormInput.vue
@@ -1,0 +1,30 @@
+<script lang="ts">
+import { Vue, Model, Component, Prop } from 'nuxt-property-decorator'
+import { PropType } from 'vue'
+import BaseValidation from '~/validation/validation'
+
+@Component({})
+export default class AbstractFormInput<
+  Input,
+  Validation extends BaseValidation | null
+> extends Vue {
+  @Prop({
+    type: Object as PropType<Validation>,
+  })
+  protected validation!: Validation
+
+  @Model('update:value', {
+    type: Object as PropType<Input>,
+    required: true,
+  })
+  protected value!: Input
+
+  protected get input() {
+    return this.value
+  }
+
+  protected set input(value) {
+    this.$emit('update:value', value)
+  }
+}
+</script>

--- a/front/components/form/AbstractVValidateInput.vue
+++ b/front/components/form/AbstractVValidateInput.vue
@@ -36,9 +36,9 @@ export default abstract class AbstractVValidateInput extends Vue {
   @Prop({ type: String })
   private vid?: String
 
-  @Prop({ type: Object as PropType<ValidationItem> } as PropOptions<
-    ValidationItem
-  >)
+  @Prop({
+    type: Object as PropType<ValidationItem>,
+  } as PropOptions<ValidationItem>)
   private validation?: ValidationItem
 
   @Prop({ type: Array as PropType<String[]> })
@@ -60,7 +60,9 @@ export default abstract class AbstractVValidateInput extends Vue {
   }
 
   get safeBackendErrors() {
-    return this.backendErrors ?? []
+    return (this.backendErrors ?? []).concat(
+      this.validation?.backendErrors ?? []
+    )
   }
 }
 </script>

--- a/front/validation/validation.ts
+++ b/front/validation/validation.ts
@@ -3,6 +3,7 @@ import { ApolloError } from 'apollo-client/errors/ApolloError.d'
 export interface ValidationItem {
   rules?: string
   attribute?: string
+  backendErrors?: string[]
 }
 
 interface ValidationItems {
@@ -19,6 +20,10 @@ export default class Validation {
 
   constructor(items: ValidationItems) {
     this.items = items
+
+    // HACK: 最初に{}と同期させることで、すべてのitemsにbackendErrors: []を付与している。
+    //       これを行わないとundefinedになるため、vueコンポーネントからの追跡ができなくなる
+    this.syncItemBackendErrors()
   }
 
   public merge(validation: Validation): Validation {
@@ -51,8 +56,14 @@ export default class Validation {
           ...error,
         }
       })
-
     this.backendErrors = errors
+    this.syncItemBackendErrors()
+  }
+
+  private syncItemBackendErrors() {
+    Object.keys(this.items).forEach((name: string) => {
+      this.items[name].backendErrors = this.backendErrors[name] ?? []
+    })
   }
 
   public getErrorMessages(name: string): string[] {

--- a/laravel/app/UseCase/Circle/UpdateCircleParticipatingInEventInput.php
+++ b/laravel/app/UseCase/Circle/UpdateCircleParticipatingInEventInput.php
@@ -14,7 +14,7 @@ class UpdateCircleParticipatingInEventInput extends CreateCircleParticipatingInE
 
     protected function attributes(): array
     {
-        return array_merge(parent::rules(), [
+        return array_merge(parent::attributes(), [
             'id' => 'サークル番号',
             'operation_user_id' => '操作ユーザ番号',
         ]);


### PR DESCRIPTION
resolve: #141 

## この PR で実装される内容
 - フォームの入力、登録/更新用の抽象コンポーネントが追加される
 - 上記が以下のコンポーネントに対して適用される
   - サークル登録編集
   - 自分も欲しい

## 確認

-   [x] サークル登録編集が動作すること
-   [x] 自分も欲しいが動作すること
![eaf765ca-f43c-45b9-a22c-8f41700b6836](https://user-images.githubusercontent.com/8841932/175779554-10bbc3d8-1956-4307-9a2a-0f92126d9d56.gif)



## 備考
