### PR TITLE
#287 サークルリストをスマホで見やすくする

### DIFF
--- a/front/components/circle-list/CircleListForm.vue
+++ b/front/components/circle-list/CircleListForm.vue
@@ -1,7 +1,7 @@
 <template>
   <v-dialog v-model="isOpenSync">
     <v-card>
-      <v-card-title>
+      <v-card-title class="pr-sm-6 pl-sm-6 pr-1 pl-1">
         <template v-if="isEditCircle">サークルリスト登録</template>
         <template v-else>
           <favorite-button v-if="circleId" :circle-id="circleId" />
@@ -12,7 +12,7 @@
           <delete-btn v-if="myCareAboutCircle" @click="dontCareCircle" />
         </template>
       </v-card-title>
-      <v-card-text>
+      <v-card-text class="pr-sm-6 pl-sm-6 pr-1 pl-1">
         <component
           :is="formState.getComponentName()"
           v-bind="formState.getAttrs()"
@@ -251,3 +251,10 @@ export default class CircleListForm extends Vue {
   }
 }
 </script>
+
+<style scoped>
+/* stylelint-disable-next-line selector-class-pattern */
+.v-card__title {
+  flex-wrap: nowrap;
+}
+</style>

--- a/front/components/circle-list/CircleListTable.vue
+++ b/front/components/circle-list/CircleListTable.vue
@@ -3,6 +3,7 @@
     :headers="headers"
     :items="filteredCircleLists"
     height="calc(100vh - 90px)"
+    :mobile-breakpoint="0"
     hide-default-footer
     disable-pagination
     fixed-header

--- a/front/components/circle-list/CircleListTable.vue
+++ b/front/components/circle-list/CircleListTable.vue
@@ -13,7 +13,7 @@
     @current-items="onUpdateTableCurrentItems"
   >
     <template #top>
-      <v-toolbar>
+      <v-toolbar class="elevation-0">
         <export-circle-list
           :is-open.sync="isOpenExportCircleList"
           :table-state="tableState"
@@ -52,7 +52,7 @@
         </v-tooltip>
       </v-toolbar>
       <v-expand-transition>
-        <v-card v-show="isShowFilter">
+        <v-card v-show="isShowFilter" tile class="elevation-0">
           <v-card-text>
             <filter-item
               v-for="filter in filters"

--- a/front/components/circle-list/join-events/JoinEventUsers.vue
+++ b/front/components/circle-list/join-events/JoinEventUsers.vue
@@ -6,6 +6,7 @@
         <v-data-table
           :headers="headers"
           :items="items"
+          :mobile-breakpoint="0"
           hide-default-footer
           disable-pagination
         >

--- a/front/components/circle-list/table/filters/FilterItem.vue
+++ b/front/components/circle-list/table/filters/FilterItem.vue
@@ -1,10 +1,15 @@
 <template>
   <v-row dense>
-    <v-col cols="2">
+    <v-col cols="12" sm="2" class="d-flex">
       <v-subheader>{{ filter.getLabel() }}</v-subheader>
     </v-col>
-    <v-col cols="10">
-      <v-chip-group v-model="selectedCondition" multiple active-class="primary">
+    <v-col cols="12" sm="10">
+      <v-chip-group
+        v-model="selectedCondition"
+        multiple
+        active-class="primary"
+        column
+      >
         <v-chip
           v-for="condition in filter.getConditionItems()"
           :key="condition.id"
@@ -45,3 +50,9 @@ export default class FilterItem extends Vue {
   }
 }
 </script>
+
+<style scoped>
+.v-subheader {
+  height: initial;
+}
+</style>

--- a/front/components/favorites/FavoriteButton.vue
+++ b/front/components/favorites/FavoriteButton.vue
@@ -6,7 +6,7 @@
         color="favorite"
         v-bind="{ ...attrs, ...$attrs }"
         v-on="on"
-        @click="toggleFavorite"
+        @click.stop="toggleFavorite"
       >
         <v-icon> {{ mdiIconName }} </v-icon>
       </v-btn>

--- a/front/components/favorites/FavoriteTable.vue
+++ b/front/components/favorites/FavoriteTable.vue
@@ -2,6 +2,7 @@
   <v-data-table
     :headers="headers"
     :items="favorites"
+    :mobile-breakpoint="0"
     hide-default-footer
     disable-pagination
     fixed-header

--- a/front/components/masters/AbstractMasterPage.vue
+++ b/front/components/masters/AbstractMasterPage.vue
@@ -11,6 +11,7 @@
       <v-data-table
         :headers="headers"
         :items="models"
+        :mobile-breakpoint="0"
         hide-default-footer
         disable-pagination
       >

--- a/front/pages/teams/_team_id/affiliation-users.vue
+++ b/front/pages/teams/_team_id/affiliation-users.vue
@@ -4,17 +4,25 @@
       <v-data-table
         :headers="headers"
         :items="items"
+        :mobile-breakpoint="0"
         hide-default-footer
         disable-pagination
       >
         <template #[`item.operations`]="{ item }">
-          <v-btn
-            color="delete"
-            @click="excludeUser(item.userAffiliationTeamId)"
-          >
-            <v-icon left>mdi-account-remove</v-icon>
-            除名
-          </v-btn>
+          <v-tooltip top>
+            <template #activator="{ on, attrs }">
+              <v-btn
+                color="delete"
+                icon
+                @click="excludeUser(item.userAffiliationTeamId)"
+                v-bind="attrs"
+                v-on="on"
+              >
+                <v-icon left>mdi-account-remove</v-icon>
+              </v-btn>
+            </template>
+            <span>除名</span>
+          </v-tooltip>
         </template>
       </v-data-table>
     </v-col>


### PR DESCRIPTION
resolve: #287 

## この PR で実装される内容
サークルリスト周りがスマホで見やすくなる

## 確認

-   [ ] 画面表示がいい感じになっていること
![image](https://user-images.githubusercontent.com/8841932/176200330-24454b1f-6a1b-46cf-b3b9-b8ce862923b1.png)
![image](https://user-images.githubusercontent.com/8841932/176200490-01c34817-603a-4834-a041-7b37d064197c.png)
![image](https://user-images.githubusercontent.com/8841932/176200610-46bfcc1a-587d-4582-9e8d-f62e55ba1234.png)

-   [ ] デスクトップ表示は今まで通りの使用感であること
![image](https://user-images.githubusercontent.com/8841932/176200681-3054077f-6df0-4150-95ef-be3c56c74df4.png)
![image](https://user-images.githubusercontent.com/8841932/176200718-275c1b67-ff2e-4faa-97dc-b94c3c276270.png)

## 備考
