### PR TITLE
#292 CircleListForm.vueのeditingCircleIdとcircleIdを統合する

### DIFF
--- a/front/components/circle-list/CircleListForm.vue
+++ b/front/components/circle-list/CircleListForm.vue
@@ -86,7 +86,7 @@ export default class CircleListForm extends Vue {
   private teamId!: String
 
   @Prop({ type: String })
-  private joinEventId!: String | null
+  private joinEventId!: String
 
   private isEditCircle: boolean = true
 
@@ -136,7 +136,7 @@ export default class CircleListForm extends Vue {
         {
           eventId: this.eventId,
           teamId: this.teamId,
-          joinEventId: this.joinEventId as String,
+          joinEventId: this.joinEventId,
           circlePlacement: this.circlePlacement,
         },
         {}
@@ -149,7 +149,7 @@ export default class CircleListForm extends Vue {
           teamId: this.teamId,
           circlePlacementId: this.circlePlacement!.id,
           circleProduct: this.editingCircleProduct,
-          joinEventId: this.joinEventId!,
+          joinEventId: this.joinEventId,
         },
         {}
       )

--- a/front/components/circle-list/CircleListForm.vue
+++ b/front/components/circle-list/CircleListForm.vue
@@ -228,10 +228,13 @@ export default class CircleListForm extends Vue {
     }
   }
 
-  private onSaved(payload?: any): void {
+  private async onSaved(payload?: any): Promise<any> {
     if (payload?.circle?.id) {
       this.circleId = payload.circle.id
+      // HACK: nextTickがないと、PropSyncでemitしたcircleIdが本コンポーネントのpropに伝達する前にほかの処理に行くため、必要
+      await this.$nextTick()
     }
+
     this.$apollo.queries.circlePlacement.refetch()
     this.cancelEdit()
     this.$emit('saved')

--- a/front/components/circle-list/CircleListForm.vue
+++ b/front/components/circle-list/CircleListForm.vue
@@ -76,6 +76,9 @@ export default class CircleListForm extends Vue {
   @PropSync('isOpen', { type: Boolean, required: true })
   private isOpenSync!: Boolean
 
+  @PropSync('editingCircleId', { type: String, default: null })
+  private circleId!: String | null
+
   @Prop({ type: String, required: true })
   private eventId!: String
 
@@ -85,12 +88,7 @@ export default class CircleListForm extends Vue {
   @Prop({ type: String })
   private joinEventId!: String | null
 
-  @Prop({ type: String, default: null })
-  private editingCircleId!: String | null
-
   private isEditCircle: boolean = true
-
-  private circleId: String | null = null
 
   private circlePlacement: CirclePlacement | null = null
 
@@ -171,9 +169,8 @@ export default class CircleListForm extends Vue {
     )
   }
 
-  @Watch('editingCircleId')
-  private onUpdateEditingCircleId(editingCircleId: string | null): void {
-    this.circleId = editingCircleId
+  @Watch('circleId')
+  private onUpdateCircleId(): void {
     this.cancelEdit()
   }
 
@@ -184,13 +181,7 @@ export default class CircleListForm extends Vue {
     this.wantMeToCircleProduct = null
   }
 
-  private initializeDisplayCircle(editingCircleId: string): void {
-    this.isEditCircle = false
-    this.circleId = editingCircleId
-  }
-
   private editCircle(): void {
-    this.cancelEdit()
     this.isEditCircle = true
   }
 

--- a/front/components/circle-list/form/CircleForm.vue
+++ b/front/components/circle-list/form/CircleForm.vue
@@ -33,7 +33,7 @@ export default class CircleForm extends Vue {
   @Prop({ type: String, required: true })
   private teamId!: String
 
-  @Prop({ type: String })
+  @Prop({ type: String, required: true })
   private joinEventId!: string
 
   @Prop({ type: Object as PropType<CirclePlacement> })

--- a/front/components/circle-list/form/circle-form/CircleEditor.vue
+++ b/front/components/circle-list/form/circle-form/CircleEditor.vue
@@ -51,7 +51,7 @@ export default class CircleEditor extends AbstractForm<CreateCircleParticipating
   @Prop({ type: String, required: true })
   private teamId!: String
 
-  @Prop({ type: String })
+  @Prop({ type: String, required: true })
   private joinEventId!: string
 
   @Prop({ type: Object as PropType<CirclePlacement>, required: true })

--- a/front/components/circle-list/form/circle-form/CircleRegister.vue
+++ b/front/components/circle-list/form/circle-form/CircleRegister.vue
@@ -59,7 +59,7 @@ export default class CircleRegister extends AbstractForm<CreateCircleParticipati
   @Prop({ type: String, required: true })
   private teamId!: String
 
-  @Prop({ type: String })
+  @Prop({ type: String, required: true })
   private joinEventId!: string
 
   protected validation: CreateCircleParticipatingInEventInputValidation =

--- a/front/pages/teams/_team_id/events/_event_id/circle-list.vue
+++ b/front/pages/teams/_team_id/events/_event_id/circle-list.vue
@@ -36,7 +36,7 @@
         :event-id="$route.params.event_id"
         :team-id="$route.params.team_id"
         :join-event-id="joinEvent ? joinEvent.id : null"
-        :editing-circle-id="editingCircleId"
+        :editing-circle-id.sync="editingCircleId"
         @saved="onSavedCircle"
       />
 

--- a/front/pages/teams/_team_id/events/_event_id/circle-list.vue
+++ b/front/pages/teams/_team_id/events/_event_id/circle-list.vue
@@ -35,7 +35,7 @@
         :is-open.sync="isOpenCircleListForm"
         :event-id="$route.params.event_id"
         :team-id="$route.params.team_id"
-        :join-event-id="joinEvent ? joinEvent.id : null"
+        :join-event-id="joinEvent.id"
         :editing-circle-id.sync="editingCircleId"
         @saved="onSavedCircle"
       />


### PR DESCRIPTION
resolve: #292 

## この PR で実装される内容
CircleListForm.vueのeditingCircleIdがPropSyncになり、circleIdを通じて親子コンポーネント間で同期された値になるようにリファクタリングされる

## 確認

-   [x] 動作に影響がないこと
![8a959c56-286a-482f-9b14-4d131256e15b](https://user-images.githubusercontent.com/8841932/176870815-f47d5149-b625-434a-9e3b-bf6b14a1f466.gif)


## 備考
