### PR TITLE
#173 お気に入りサークルのイベントへのチェックリスト機能を実装する

### DIFF
--- a/front/apollo/mutations/cancelNotParticipateCircleInEvent.gql
+++ b/front/apollo/mutations/cancelNotParticipateCircleInEvent.gql
@@ -1,0 +1,5 @@
+mutation CancelNotParticipateCircleInEventMutation($circleId: ID!, $eventId: ID!) {
+  cancelNotParticipateCircleInEvent(circle_id: $circleId, event_id: $eventId) {
+    id
+  }
+}

--- a/front/apollo/mutations/notParticipateCircleInEvent.gql
+++ b/front/apollo/mutations/notParticipateCircleInEvent.gql
@@ -1,0 +1,5 @@
+mutation NotParticipateCircleInEventMutation($circleId: ID!, $eventId: ID!) {
+  notParticipateCircleInEvent(circle_id: $circleId, event_id: $eventId) {
+    id
+  }
+}

--- a/front/apollo/queries/circle.gql
+++ b/front/apollo/queries/circle.gql
@@ -1,0 +1,7 @@
+query CircleQuery($id: ID!) {
+  circle(id: $id) {
+    id
+    name
+    kana
+  }
+}

--- a/front/apollo/queries/myFavoriteInEvents.gql
+++ b/front/apollo/queries/myFavoriteInEvents.gql
@@ -1,0 +1,12 @@
+query MyFavoritesInEventsQuery($eventId: ID!) {
+  myFavoritesInEvent(event_id: $eventId) {
+    favorite {
+      id
+      circle {
+        id
+        name
+      }
+    }
+    state
+  }
+}

--- a/front/components/circle-list/CircleListForm.vue
+++ b/front/components/circle-list/CircleListForm.vue
@@ -138,6 +138,7 @@ export default class CircleListForm extends Vue {
           teamId: this.teamId,
           joinEventId: this.joinEventId,
           circlePlacement: this.circlePlacement,
+          circleId: this.circleId,
         },
         {}
       )
@@ -164,19 +165,30 @@ export default class CircleListForm extends Vue {
         'edit-circle-product': this.editCircleProduct,
         'want-me-too': this.onWantMeToo,
         'add-circle-product': this.addCircleProduct,
-        'register-new-circle': this.clearForm,
+        'register-new-circle': this.initializeForm,
       }
     )
   }
 
   @Watch('circleId')
   private onUpdateCircleId(): void {
+    if (!this.circleId) {
+      this.circlePlacement = null
+    }
+  }
+
+  @Watch('circlePlacement')
+  private onUpdateCirclePlacement(): void {
     this.cancelEdit()
+  }
+
+  private initializeForm(): void {
+    this.circleId = null
+    this.clearForm()
   }
 
   private clearForm(): void {
     this.isEditCircle = true
-    this.circleId = null
     this.circlePlacement = null
     this.wantMeToCircleProduct = null
   }
@@ -223,7 +235,7 @@ export default class CircleListForm extends Vue {
     this.editingCircleProduct = null
     this.wantMeToCircleProduct = null
 
-    if (!this.circleId) {
+    if (!this.circlePlacement) {
       this.clearForm()
     }
   }

--- a/front/components/circle-list/FavoriteCircleListTable.vue
+++ b/front/components/circle-list/FavoriteCircleListTable.vue
@@ -1,0 +1,103 @@
+<template>
+  <v-data-table
+    :headers="headers"
+    :items="favoritesWithState"
+    height="calc(100vh - 90px)"
+    :mobile-breakpoint="0"
+    hide-default-footer
+    disable-pagination
+    fixed-header
+    multi-sort
+    @click:row="onRowClicked"
+    @dblclick:row="onRowDblClicked"
+  >
+    <template #top>
+      <circle-list-table-setting
+        v-model="settings"
+        :is-open.sync="isOpenSetting"
+      />
+      <v-toolbar class="elevation-0">
+        <v-toolbar-title>お気に入りチェックリスト</v-toolbar-title>
+        <v-spacer />
+        <v-tooltip top>
+          <template #activator="{ on, attrs }">
+            <v-btn icon v-bind="attrs" @click="openSetting" v-on="on">
+              <v-icon>mdi-cog</v-icon>
+            </v-btn>
+          </template>
+          <span>設定</span>
+        </v-tooltip>
+      </v-toolbar>
+    </template>
+    <template #[`item.favorite.circle.name`]="{ item }">
+      <favorite-state-button :event-id="eventId" :favorite-with-state="item" />
+      {{ item.favorite.circle.name }}
+    </template>
+  </v-data-table>
+</template>
+
+<script lang="ts">
+import { PropType } from 'vue'
+import { Vue, Component, Prop, Emit } from 'nuxt-property-decorator'
+import { DataTableHeader } from 'vuetify/types/index'
+import FilterItem from './table/filters/FilterItem.vue'
+import CircleListTableSetting, {
+  CircleListTableSettings,
+} from './table/CircleListTableSetting.vue'
+import FavoriteStateButton from '~/components/favorites/FavoriteStateButton.vue'
+import { FavoriteWithState } from '~/apollo/graphql'
+
+@Component({
+  components: {
+    FilterItem,
+    CircleListTableSetting,
+    FavoriteStateButton,
+  },
+})
+export default class CircleListTable extends Vue {
+  @Prop({ type: Array as PropType<FavoriteWithState[]> })
+  private favoritesWithState!: FavoriteWithState[]
+
+  @Prop({
+    type: String,
+    required: true,
+  })
+  private eventId!: string
+
+  private isOpenSetting: boolean = false
+
+  // HACK: 初期値を指定しているが、子コンポーネントのmountedのタイミングで保存済みの値があれば、v-modelのイベント経由で変更される。
+  //       ちょっと複雑な動作をしているため、シンプルな実装にできるのであれば、変更も考えたい
+  private settings: CircleListTableSettings = {
+    howOpenCircleListForm: 'click',
+  }
+
+  private readonly headers: DataTableHeader[] = [
+    {
+      text: 'サークル名',
+      value: 'favorite.circle.name',
+    },
+  ]
+
+  private openSetting(): void {
+    this.isOpenSetting = true
+  }
+
+  private onRowClicked(e: any, row: { item: FavoriteWithState }) {
+    if (this.settings.howOpenCircleListForm === 'click') {
+      this.openCircleListForm(e, row.item)
+    }
+  }
+
+  private onRowDblClicked(e: any, row: { item: FavoriteWithState }) {
+    if (this.settings.howOpenCircleListForm === 'dblclick') {
+      this.openCircleListForm(e, row.item)
+    }
+  }
+
+  @Emit()
+  private openCircleListForm(_: any, row: FavoriteWithState) {
+    return { circle_id: row.favorite.circle!.id }
+  }
+}
+</script>

--- a/front/components/circle-list/form/CircleForm.vue
+++ b/front/components/circle-list/form/CircleForm.vue
@@ -4,6 +4,7 @@
     :event-id="eventId"
     :join-event-id="joinEventId"
     :team-id="teamId"
+    :circle-id="circleId"
     v-on="$listeners"
   />
   <circle-editor
@@ -38,5 +39,8 @@ export default class CircleForm extends Vue {
 
   @Prop({ type: Object as PropType<CirclePlacement> })
   private circlePlacement!: CirclePlacement | null
+
+  @Prop({ type: String })
+  private circleId!: string | null
 }
 </script>

--- a/front/components/circle-list/form/circle-form/CircleFormInput.vue
+++ b/front/components/circle-list/form/circle-form/CircleFormInput.vue
@@ -4,6 +4,7 @@
       <v-col cols="12">
         <v-validate-text-field
           v-model="input.name"
+          :disabled="disabled"
           :validation="validation.getItem('circle.name')"
         />
       </v-col>
@@ -11,14 +12,18 @@
 
     <v-row dense>
       <v-col cols="12">
-        <v-text-field v-model="input.kana" placeholder="サークルの読み方" />
+        <v-text-field
+          v-model="input.kana"
+          :disabled="disabled"
+          placeholder="サークルの読み方"
+        />
       </v-col>
     </v-row>
   </v-container>
 </template>
 
 <script lang="ts">
-import { Component } from 'nuxt-property-decorator'
+import { Component, Prop } from 'nuxt-property-decorator'
 import AbstractFormInput from '~/components/form/AbstractFormInput.vue'
 import { CircleInput } from '~/apollo/graphql'
 import { CreateCircleParticipatingInEventInputValidation } from '~/validation/validations'
@@ -27,5 +32,8 @@ import { CreateCircleParticipatingInEventInputValidation } from '~/validation/va
 export default class CircleFormInput extends AbstractFormInput<
   CircleInput,
   CreateCircleParticipatingInEventInputValidation
-> {}
+> {
+  @Prop({ type: Boolean, default: false })
+  private disabled!: boolean
+}
 </script>

--- a/front/components/circle-list/form/states/CircleFormState.ts
+++ b/front/components/circle-list/form/states/CircleFormState.ts
@@ -6,6 +6,7 @@ type CircleFormStateProps = {
   teamId: String
   joinEventId: String
   circlePlacement?: CirclePlacement | null
+  circleId: String | null
 }
 
 type CircleFormStateEventObservers = {}

--- a/front/components/favorites/FavoriteButton.vue
+++ b/front/components/favorites/FavoriteButton.vue
@@ -76,6 +76,7 @@ export default class FavoriteButton extends Vue {
         variables: {
           input,
         },
+        refetchQueries: ['MyFavoritesInEventsQuery'],
       })
       .then(() => {
         this.$toast.success('お気に入りに追加しました')
@@ -91,6 +92,7 @@ export default class FavoriteButton extends Vue {
       .mutate({
         mutation: DeleteFavoriteMutation,
         variables,
+        refetchQueries: ['MyFavoritesInEventsQuery'],
       })
       .then(() => {
         this.$toast.success('お気に入りの登録を解除しました')

--- a/front/components/favorites/FavoriteStateButton.vue
+++ b/front/components/favorites/FavoriteStateButton.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-menu offset-y v-model="isOpenMenu">
+  <v-menu v-model="isOpenMenu" offset-y>
     <template #activator="menuSlot">
       <v-tooltip top>
         <template #activator="{ on, attrs }">

--- a/front/components/favorites/FavoriteStateButton.vue
+++ b/front/components/favorites/FavoriteStateButton.vue
@@ -1,0 +1,176 @@
+<template>
+  <v-menu offset-y v-model="isOpenMenu">
+    <template #activator="menuSlot">
+      <v-tooltip top>
+        <template #activator="{ on, attrs }">
+          <v-btn
+            icon
+            :color="mdiIconColor"
+            v-bind="{ ...attrs, ...menuSlot.attrs, ...$attrs }"
+            v-on="{ ...on }"
+            @click.stop="openMenu"
+          >
+            <v-icon> {{ mdiIconName }} </v-icon>
+          </v-btn>
+        </template>
+        <span>{{ tooltipMessage }}</span>
+      </v-tooltip>
+    </template>
+    <v-list>
+      <v-list-item
+        v-if="isNotParticipation"
+        link
+        @click="cancelNotParticipateCircleInEvent"
+      >
+        <v-list-item-title>
+          <v-icon color="warning">mdi-help-circle</v-icon>
+          不参加を取り消す
+        </v-list-item-title>
+      </v-list-item>
+      <v-list-item
+        v-else-if="isUnchecked"
+        link
+        @click="notParticipateCircleInEvent"
+      >
+        <v-list-item-title>
+          <v-icon color="secondary">mdi-close-circle</v-icon>
+          不参加にする
+        </v-list-item-title>
+      </v-list-item>
+    </v-list>
+  </v-menu>
+</template>
+
+<script lang="ts">
+import { PropType } from 'vue'
+import { Vue, Component, Prop } from 'nuxt-property-decorator'
+import {
+  FavoriteWithState,
+  CancelNotParticipateCircleInEventMutation,
+  NotParticipateCircleInEventMutation,
+} from '~/apollo/graphql'
+import InvalidArgumentException from '~/exceptions/InvalidArgumentException'
+
+type FavoriteStateIcon = {
+  name: string
+  icon: string
+  color: string
+}
+
+const icons: FavoriteStateIcon[] = [
+  {
+    name: '未確認',
+    icon: 'mdi-help-circle',
+    color: 'warning',
+  },
+  {
+    name: '参加',
+    icon: 'mdi-store-check',
+    color: 'warning',
+  },
+  {
+    name: '不参加',
+    icon: 'mdi-close-circle',
+    color: 'secondary',
+  },
+  {
+    name: 'チェック済',
+    icon: 'mdi-check-circle',
+    color: 'primary',
+  },
+]
+
+@Component({ inheritAttrs: false })
+export default class FavoriteStateButton extends Vue {
+  @Prop({
+    type: Object as PropType<FavoriteWithState>,
+    required: true,
+  })
+  private favoriteWithState!: FavoriteWithState
+
+  @Prop({
+    type: String,
+    required: true,
+  })
+  private eventId!: string
+
+  private isOpenMenu: boolean = false
+
+  private get tooltipMessage(): string {
+    return this.favoriteWithState.state
+  }
+
+  private get icon(): FavoriteStateIcon {
+    const icon = icons.find(
+      (searchIcon) => searchIcon.name === this.favoriteWithState.state
+    )
+    if (!icon) {
+      throw new InvalidArgumentException(
+        `${this.favoriteWithState.state}に対応するアイコンが設定されていません`
+      )
+    }
+    return icon
+  }
+
+  private get mdiIconName(): string {
+    return this.icon.icon
+  }
+
+  private get mdiIconColor(): string {
+    return this.icon.color
+  }
+
+  private get isNotParticipation(): boolean {
+    return this.favoriteWithState.state === '不参加'
+  }
+
+  private get isUnchecked(): boolean {
+    return this.favoriteWithState.state === '未確認'
+  }
+
+  private openMenu(): void {
+    if (!this.isNotParticipation && !this.isUnchecked) {
+      return
+    }
+    this.isOpenMenu = true
+  }
+
+  private async notParticipateCircleInEvent(): Promise<any> {
+    const variables = {
+      circleId: this.favoriteWithState.favorite.circle!.id,
+      eventId: this.eventId,
+    }
+
+    try {
+      await this.$apollo.mutate({
+        mutation: NotParticipateCircleInEventMutation,
+        variables,
+        refetchQueries: ['MyFavoritesInEventsQuery'],
+      })
+
+      this.$toast.success('不参加にしました')
+    } catch (e) {
+      this.$toast.error('エラーが発生しました')
+    }
+  }
+
+  private async cancelNotParticipateCircleInEvent(): Promise<any> {
+    const variables = {
+      circleId: this.favoriteWithState.favorite.circle!.id,
+      eventId: this.eventId,
+    }
+
+    try {
+      await this.$apollo.mutate({
+        mutation: CancelNotParticipateCircleInEventMutation,
+        variables,
+        refetchQueries: ['MyFavoritesInEventsQuery'],
+      })
+
+      this.$toast.success('不参加を取り消しました')
+    } catch (e) {
+      this.$toast.error('エラーが発生しました')
+    }
+  }
+}
+</script>

--- a/laravel/app/GraphQL/Mutations/CancelNotParticipateCircleInEvent.php
+++ b/laravel/app/GraphQL/Mutations/CancelNotParticipateCircleInEvent.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\GraphQL\Mutations;
+
+use Illuminate\Support\Arr;
+
+use App\UseCase\Circle\CancelNotParticipateCircleInEvent as CancelNotParticipateCircleInEventUseCase;
+use App\UseCase\Circle\CancelNotParticipateCircleInEventInput;
+
+class CancelNotParticipateCircleInEvent
+{
+    /**
+     * @param  null  $_
+     * @param  array<string, mixed>  $args
+     */
+    public function __invoke($_, array $args)
+    {
+        $data = Arr::except($args, ['directive']);
+        $input = new CancelNotParticipateCircleInEventInput($data);
+        return (new CancelNotParticipateCircleInEventUseCase())->execute($input)->circle;
+    }
+}

--- a/laravel/app/GraphQL/Mutations/NotParticipateCircleInEvent.php
+++ b/laravel/app/GraphQL/Mutations/NotParticipateCircleInEvent.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\GraphQL\Mutations;
+
+use Illuminate\Support\Arr;
+
+use App\UseCase\Circle\NotParticipateCircleInEvent as NotParticipateCircleInEventUseCase;
+use App\UseCase\Circle\NotParticipateCircleInEventInput;
+
+class NotParticipateCircleInEvent
+{
+    /**
+     * @param  null  $_
+     * @param  array<string, mixed>  $args
+     */
+    public function __invoke($_, array $args)
+    {
+        $data = Arr::except($args, ['directive']);
+        $input = new NotParticipateCircleInEventInput($data);
+        return (new NotParticipateCircleInEventUseCase())->execute($input)->circle;
+    }
+}

--- a/laravel/app/GraphQL/Queries/CirclePlacementInEvent.php
+++ b/laravel/app/GraphQL/Queries/CirclePlacementInEvent.php
@@ -17,6 +17,6 @@ class CirclePlacementInEvent
 
         return CirclePlacement::inEvent($eventId)
             ->where('circle_id', $circleId)
-            ->firstOrFail();
+            ->first();
     }
 }

--- a/laravel/app/GraphQL/Queries/MyFavoriteCircleLists.php
+++ b/laravel/app/GraphQL/Queries/MyFavoriteCircleLists.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\GraphQL\Queries;
+
+use Auth;
+
+class MyFavoriteCircleLists
+{
+    /**
+     * @param  null  $_
+     * @param  array<string, mixed>  $args
+     */
+    public function __invoke($_, array $args)
+    {
+        $eventId = $args['event_id'];
+        $user = Auth::user();
+        $user->load('favorites.circle');
+        return $user->favorites->map(fn ($favorite) => [
+            'favorite' => $favorite,
+            'state' => $favorite->participateInEventState($eventId),
+        ]);
+    }
+}

--- a/laravel/app/Models/Circle.php
+++ b/laravel/app/Models/Circle.php
@@ -20,4 +20,25 @@ class Circle extends Model
     {
         return $this->hasMany(Favorite::class);
     }
+
+    public function notParticipationCircles(): HasMany
+    {
+        return $this->hasMany(NotParticipationCircle::class);
+    }
+
+    public function participateInEventState(string $eventId): string
+    {
+        // FIXME: ステータスを文字列で返しているのは微妙なので、ステータスを表すクラスなり、定数なりを用意する
+        //        できればフロントエンドにも共有できる仕組みがあるとよい
+        if ($this->notParticipationCircles()->where('event_id', $eventId)->exists()) {
+            return '不参加';
+        }
+
+        $eventDates = Event::findOrFail($eventId)->eventDates()->pluck('id');
+        if ($this->circlePlacements()->whereIn('event_date_id', $eventDates)->exists()) {
+            return '参加';
+        }
+
+        return '未確認';
+    }
 }

--- a/laravel/app/Models/Circle.php
+++ b/laravel/app/Models/Circle.php
@@ -30,13 +30,13 @@ class Circle extends Model
     {
         // FIXME: ステータスを文字列で返しているのは微妙なので、ステータスを表すクラスなり、定数なりを用意する
         //        できればフロントエンドにも共有できる仕組みがあるとよい
-        if ($this->notParticipationCircles()->where('event_id', $eventId)->exists()) {
-            return '不参加';
-        }
-
         $eventDates = Event::findOrFail($eventId)->eventDates()->pluck('id');
         if ($this->circlePlacements()->whereIn('event_date_id', $eventDates)->exists()) {
             return '参加';
+        }
+
+        if ($this->notParticipationCircles()->where('event_id', $eventId)->exists()) {
+            return '不参加';
         }
 
         return '未確認';

--- a/laravel/app/Models/Favorite.php
+++ b/laravel/app/Models/Favorite.php
@@ -23,4 +23,15 @@ class Favorite extends Model
     {
         return $this->belongsTo(User::class);
     }
+
+    public function participateInEventState(string $eventId): string
+    {
+        $eventDates = Event::findOrFail($eventId)->eventDates()->pluck('id');
+        $circlePlacement = $this->circle->circlePlacements()->whereIn('event_date_id', $eventDates)->first();
+        if ($circlePlacement && $circlePlacement->careAboutCircles()->whereHasUser($this->user_id)->exists()) {
+            return 'チェック済';
+        }
+
+        return $this->circle->participateInEventState($eventId);
+    }
 }

--- a/laravel/app/Models/NotParticipationCircle.php
+++ b/laravel/app/Models/NotParticipationCircle.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class NotParticipationCircle extends Model
+{
+    use HasFactory;
+
+    protected $fillable = ['circle_id', 'event_id'];
+
+    public function event(): BelongsTo
+    {
+        return $this->belongsTo(Event::class);
+    }
+
+
+    public function circle(): BelongsTo
+    {
+        return $this->belongsTo(Circle::class);
+    }
+}

--- a/laravel/app/UseCase/Circle/CancelNotParticipateCircleInEvent.php
+++ b/laravel/app/UseCase/Circle/CancelNotParticipateCircleInEvent.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\UseCase\Circle;
+
+use App\Models\NotParticipationCircle;
+use App\UseCase\UseCase;
+
+class CancelNotParticipateCircleInEvent extends UseCase
+{
+    public function execute(CancelNotParticipateCircleInEventInput $input): NotParticipationCircle
+    {
+        $notParticipationCircle = NotParticipationCircle::where('circle_id', $input->get('circle_id'))
+            ->where('event_id', $input->get('event_id'))
+            ->firstOrFail();
+        $notParticipationCircle->delete();
+        return $notParticipationCircle;
+    }
+}

--- a/laravel/app/UseCase/Circle/CancelNotParticipateCircleInEventInput.php
+++ b/laravel/app/UseCase/Circle/CancelNotParticipateCircleInEventInput.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\UseCase\Circle;
+
+use App\UseCase\UseCaseInput;
+
+class CancelNotParticipateCircleInEventInput extends UseCaseInput
+{
+    protected function rules(): array
+    {
+        return [
+            'circle_id' => 'required',
+            'event_id' => 'required',
+        ];
+    }
+
+    protected function attributes(): array
+    {
+        return [
+            'circle_id' => 'サークル番号',
+            'event_id' => 'イベント番号',
+        ];
+    }
+}

--- a/laravel/app/UseCase/Circle/CreateCircleParticipatingInEvent.php
+++ b/laravel/app/UseCase/Circle/CreateCircleParticipatingInEvent.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Facades\DB;
 use App\Models\Circle;
 use App\Models\CirclePlacement;
 use App\Models\EventDate;
+use App\Models\NotParticipationCircle;
 use App\UseCase\UseCase;
 
 class CreateCircleParticipatingInEvent extends UseCase
@@ -41,6 +42,13 @@ class CreateCircleParticipatingInEvent extends UseCase
     private function cancelNotParticipateCircleInEvent(CreateCircleParticipatingInEventInput $input, string $circleId)
     {
         $eventId = EventDate::findOrFail($input->getPlacementData()['event_date_id'])->event_id;
+        $isExistsNotParticipationCircle = NotParticipationCircle::where('circle_id', $circleId)
+            ->where('event_id', $eventId)
+            ->exists();
+        if (!$isExistsNotParticipationCircle) {
+            return;
+        }
+
         $cancelInput = new CancelNotParticipateCircleInEventInput([
             'event_id' => $eventId,
             'circle_id' => $circleId,

--- a/laravel/app/UseCase/Circle/CreateCircleParticipatingInEvent.php
+++ b/laravel/app/UseCase/Circle/CreateCircleParticipatingInEvent.php
@@ -6,6 +6,7 @@ use Illuminate\Support\Facades\DB;
 
 use App\Models\Circle;
 use App\Models\CirclePlacement;
+use App\Models\EventDate;
 use App\UseCase\UseCase;
 
 class CreateCircleParticipatingInEvent extends UseCase
@@ -13,12 +14,12 @@ class CreateCircleParticipatingInEvent extends UseCase
     public function execute(CreateCircleParticipatingInEventInput $input)
     {
         $circle = DB::transaction(function () use ($input) {
-            $circleData = $input->getCircleData();
-            $circle = Circle::create($circleData);
-
+            $circle = $this->findOrCreate($input);
             $placementData = $input->getPlacementData();
             $placementData['circle_id'] = $circle->id;
             $circlePlacement = CirclePlacement::create($placementData);
+
+            $this->cancelNotParticipateCircleInEvent($input, $circle->id);
 
             $circle->refresh();
 
@@ -26,5 +27,24 @@ class CreateCircleParticipatingInEvent extends UseCase
         });
 
         return $circle;
+    }
+
+    private function findOrCreate(CreateCircleParticipatingInEventInput $input)
+    {
+        $circleData = $input->getCircleData();
+        if ($circleData['id'] ?? false) {
+            return Circle::findOrFail($circleData['id']);
+        }
+        return Circle::create($circleData);
+    }
+
+    private function cancelNotParticipateCircleInEvent(CreateCircleParticipatingInEventInput $input, string $circleId)
+    {
+        $eventId = EventDate::findOrFail($input->getPlacementData()['event_date_id'])->event_id;
+        $cancelInput = new CancelNotParticipateCircleInEventInput([
+            'event_id' => $eventId,
+            'circle_id' => $circleId,
+        ]);
+        (new CancelNotParticipateCircleInEvent())->execute($cancelInput);
     }
 }

--- a/laravel/app/UseCase/Circle/NotParticipateCircleInEvent.php
+++ b/laravel/app/UseCase/Circle/NotParticipateCircleInEvent.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\UseCase\Circle;
+
+use App\Models\NotParticipationCircle;
+use App\UseCase\UseCase;
+
+class NotParticipateCircleInEvent extends UseCase
+{
+    public function execute(NotParticipateCircleInEventInput $input): NotParticipationCircle
+    {
+        $notParticipateCircleInEventData = $input->toArray();
+        $notParticipateCircleInEvent = NotParticipationCircle::create($notParticipateCircleInEventData);
+        return $notParticipateCircleInEvent;
+    }
+}

--- a/laravel/app/UseCase/Circle/NotParticipateCircleInEventInput.php
+++ b/laravel/app/UseCase/Circle/NotParticipateCircleInEventInput.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\UseCase\Circle;
+
+use App\UseCase\UseCaseInput;
+
+class NotParticipateCircleInEventInput extends UseCaseInput
+{
+    protected function rules(): array
+    {
+        return [
+            'circle_id' => 'required',
+            'event_id' => 'required',
+        ];
+    }
+
+    protected function attributes(): array
+    {
+        return [
+            'circle_id' => 'サークル番号',
+            'event_id' => 'イベント番号',
+        ];
+    }
+}

--- a/laravel/database/factories/NotParticipationCircleFactory.php
+++ b/laravel/database/factories/NotParticipationCircleFactory.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+use App\Models\Circle;
+use App\Models\Event;
+use App\Models\NotParticipationCircle;
+
+class NotParticipationCircleFactory extends Factory
+{
+    /**
+     * The name of the factory's corresponding model.
+     *
+     * @var string
+     */
+    protected $model = NotParticipationCircle::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array
+     */
+    public function definition()
+    {
+        return [
+            'event_id' => Event::factory(),
+            'circle_id' => Circle::factory(),
+        ];
+    }
+}

--- a/laravel/database/migrations/2022_07_01_095959_create_not_participation_circles_table.php
+++ b/laravel/database/migrations/2022_07_01_095959_create_not_participation_circles_table.php
@@ -1,0 +1,41 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateNotParticipationCirclesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('not_participation_circles', function (Blueprint $table) {
+            $table->uuid('id');
+            $table
+                ->foreignUuid('circle_id')
+                ->constrained()
+                ->onUpdate('cascade')
+                ->onDelete('cascade');
+            $table
+                ->foreignUuid('event_id')
+                ->constrained()
+                ->onUpdate('cascade')
+                ->onDelete('cascade');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('not_participation_circles');
+    }
+}

--- a/laravel/graphql/circle.graphql
+++ b/laravel/graphql/circle.graphql
@@ -8,6 +8,7 @@ type Circle {
 }
 
 input CircleInput {
+    id: String
     name: String!
     kana: String
     memo: String
@@ -41,5 +42,17 @@ extend type Mutation @guard {
     ): CirclePlacement!
         @field(
             resolver: "App\\GraphQL\\Mutations\\UpdateCircleParticipatingInEvent"
+        )
+    notParticipateCircleInEvent(
+        circle_id: ID!,
+        event_id: ID!,
+    ): Circle! @field(
+            resolver: "App\\GraphQL\\Mutations\\NotParticipateCircleInEvent"
+        )
+    cancelNotParticipateCircleInEvent(
+        circle_id: ID!,
+        event_id: ID!,
+    ): Circle! @field(
+            resolver: "App\\GraphQL\\Mutations\\CancelNotParticipateCircleInEvent"
         )
 }

--- a/laravel/graphql/circlePlacement.graphql
+++ b/laravel/graphql/circlePlacement.graphql
@@ -24,5 +24,5 @@ input CirclePlacementInput {
 }
 
 extend type Query @guard {
-    circlePlacementInEvent(circle_id: ID!, event_id: ID!): CirclePlacement!
+    circlePlacementInEvent(circle_id: ID!, event_id: ID!): CirclePlacement
 }

--- a/laravel/graphql/favorite.graphql
+++ b/laravel/graphql/favorite.graphql
@@ -9,6 +9,11 @@ type Favorite {
     updated_at: DateTime
 }
 
+type FavoriteWithState {
+    favorite: Favorite!
+    state: String!
+}
+
 input FavoriteInput {
     circle_id: ID!
     user_id: ID!
@@ -20,6 +25,9 @@ extend type Query @guard {
         @find
     myFavorites: [Favorite]! @field(
             resolver: "App\\GraphQL\\Queries\\MyFavorites"
+        )
+    myFavoritesInEvent(event_id: ID!): [FavoriteWithState]!  @field(
+            resolver: "App\\GraphQL\\Queries\\MyFavoriteCircleLists"
         )
 }
 

--- a/laravel/tests/Feature/Models/CircleTest.php
+++ b/laravel/tests/Feature/Models/CircleTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Tests\Feature\Models;
+
+use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+
+use App\Models\Circle;
+use App\Models\CirclePlacement;
+use App\Models\Event;
+use App\Models\NotParticipationCircle;
+use Tests\TestCase;
+
+class CircleTest extends TestCase
+{
+    use WithFaker;
+    use RefreshDatabase;
+
+    public function testParticipateInEventState()
+    {
+        $circle = Circle::factory()->create();
+        $event = Event::factory()->create();
+        $this->assertEquals($circle->participateInEventState($event->id), '未確認');
+
+        $notParticipationCircle = NotParticipationCircle::factory([
+            'circle_id' => $circle->id,
+        ])->create();
+        $circle->refresh();
+        $this->assertEquals($circle->participateInEventState($notParticipationCircle->event_id), '不参加');
+        $notParticipationCircle->delete();
+
+        $circlePlacement = CirclePlacement::factory([
+            'circle_id' => $circle->id,
+        ])->create();
+        $eventId = $circlePlacement->eventDate->event_id;
+        $this->assertEquals($circle->participateInEventState($eventId), '参加');
+
+        $this->expectException(ModelNotFoundException::class);
+        $circle->participateInEventState('dummy');
+    }
+}

--- a/laravel/tests/Feature/Models/FavoriteTest.php
+++ b/laravel/tests/Feature/Models/FavoriteTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Tests\Feature\Models;
+
+use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+
+use App\Models\CareAboutCircle;
+use App\Models\Circle;
+use App\Models\CirclePlacement;
+use App\Models\Event;
+use App\Models\Favorite;
+use App\Models\JoinEvent;
+use App\Models\NotParticipationCircle;
+use Tests\TestCase;
+
+class FavoriteTest extends TestCase
+{
+    use WithFaker;
+    use RefreshDatabase;
+
+    public function testParticipateInEventState()
+    {
+        $circle = Circle::factory()->create();
+        $favorite = Favorite::factory([
+            'circle_id' => $circle->id,
+        ])->create();
+        $event = Event::factory()->create();
+        $this->assertEquals($favorite->participateInEventState($event->id), '未確認');
+
+        $notParticipationCircle = NotParticipationCircle::factory([
+            'circle_id' => $circle->id,
+        ])->create();
+        $circle->refresh();
+        $this->assertEquals($favorite->participateInEventState($notParticipationCircle->event_id), '不参加');
+        $notParticipationCircle->delete();
+
+        $circlePlacement = CirclePlacement::factory([
+            'circle_id' => $circle->id,
+        ])->create();
+        $eventId = $circlePlacement->eventDate->event_id;
+        $this->assertEquals($favorite->participateInEventState($eventId), '参加');
+
+        $joinEvent = JoinEvent::factory([
+            'user_id' => $favorite->user_id,
+            'event_id' => $eventId,
+        ])->create();
+        CareAboutCircle::factory([
+            'join_event_id' => $joinEvent->id,
+            'circle_placement_id' => $circlePlacement->id,
+        ]);
+
+        $this->expectException(ModelNotFoundException::class);
+        $favorite->participateInEventState('dummy');
+    }
+}


### PR DESCRIPTION
resolve: #173 

## この PR で実装される内容
お気に入りサークルのイベントへのチェックリスト機能が実装される
 - サークルリスト画面にお気に入りタブ追加
 - 該当タブでお気に入りサークル一覧が見れる
   - お気に入りにしているサークルが「不参加」「参加」「チェック済」「未確認」のどのステータスかを確認できる
   - ステータスをクリックして「不参加」に設定できる
   - 行を選択することで、サークル名と読み仮名が補完された状態でサークル登録画面を開くことができる

## 確認

-   [x] お気に入りチェックリストを表示できること
-   [x] 行選択時のサークル登録画面が動作すること
-   [x] ステータスの変更ができること
![3e751424-b265-4b9e-9e30-d16b8db0e62b](https://user-images.githubusercontent.com/8841932/176953778-55f57223-52fa-407e-a4f4-6467706f09d5.gif)


## 備考
