### PR TITLE
#301 同一イベント下でサークル被り、配置被りを考慮する

### DIFF
--- a/front/apollo/mutations/createCircleParticipatingInEvent.gql
+++ b/front/apollo/mutations/createCircleParticipatingInEvent.gql
@@ -1,7 +1,8 @@
 mutation CreateCircleParticipatingInEventMutation(
   $input: CreateCircleParticipatingInEventInput!
+  $force: Boolean
 ) {
-  createCircleParticipatingInEvent(input: $input) {
+  createCircleParticipatingInEvent(input: $input, force: $force) {
     id
     circle {
       id

--- a/front/components/circle-list/form/circle-form/CircleRegister.vue
+++ b/front/components/circle-list/form/circle-form/CircleRegister.vue
@@ -23,6 +23,9 @@
 
 <script lang="ts">
 import { Prop, Component, Watch } from 'nuxt-property-decorator'
+import { ApolloError } from 'apollo-client/errors/ApolloError'
+import { GraphQLError } from 'graphql'
+
 import CircleFormInput from './CircleFormInput.vue'
 import CirclePlacementFormInput, {
   DraftCirclePlacementInput,
@@ -104,6 +107,8 @@ export default class CircleRegister extends AbstractForm<CreateCircleParticipati
     ...initialCirclePlacementInput,
   }
 
+  private force: boolean = false
+
   private get disabledCircleForm(): boolean {
     return !!this.circleId
   }
@@ -120,11 +125,12 @@ export default class CircleRegister extends AbstractForm<CreateCircleParticipati
       circle: this.circleInput,
       placement: this.circlePlacementInput as CirclePlacementInput,
     }
+    const force = this.force
 
     return await this.$apollo
       .mutate({
         mutation: CreateCircleParticipatingInEventMutation,
-        variables: { input },
+        variables: { input, force },
       })
       .then((res) => res.data.createCircleParticipatingInEvent)
   }
@@ -133,6 +139,33 @@ export default class CircleRegister extends AbstractForm<CreateCircleParticipati
     await this.createCareAboutCircle(circlePlacement)
     const circle = circlePlacement.circle
     this.$emit('saved', { circle })
+  }
+
+  protected async handleGraphQLError(
+    graphQLError: GraphQLError,
+    apolloError: ApolloError
+  ) {
+    if (graphQLError.extensions.category === 'validation') {
+      this.handleValidationError(apolloError)
+    }
+    if (graphQLError.extensions.category === 'conflictCircle') {
+      if (await this.confirmForceCreate(graphQLError)) {
+        this.force = true
+        try {
+          await this.submit()
+        } finally {
+          this.force = false
+        }
+      }
+    }
+  }
+
+  private async confirmForceCreate(
+    graphQLError: GraphQLError
+  ): Promise<Boolean> {
+    return await this.$confirmDialog.confirm(
+      'サークル、配置が競合しています。再度確認してください。（はいを選ぶと強制的に登録します。）'
+    )
   }
 
   private async createCareAboutCircle(circlePlacement: CirclePlacement) {

--- a/front/components/circle-list/form/circle-form/CircleRegister.vue
+++ b/front/components/circle-list/form/circle-form/CircleRegister.vue
@@ -163,8 +163,18 @@ export default class CircleRegister extends AbstractForm<CreateCircleParticipati
   private async confirmForceCreate(
     graphQLError: GraphQLError
   ): Promise<Boolean> {
+    const conflictCirclesMessage: string = graphQLError.extensions.conflicts
+      .map(
+        (circlePlacement: any) =>
+          `${circlePlacement.circle.name}（${circlePlacement.formatted_placement}）`
+      )
+      .join(`\n`)
+
     return await this.$confirmDialog.confirm(
-      'サークル、配置が競合しています。再度確認してください。（はいを選ぶと強制的に登録します。）'
+      `以下のサークルと競合しています。再度確認してください。（実行を選ぶと登録します。）
+
+      ${conflictCirclesMessage}
+      `
     )
   }
 

--- a/front/components/dialog/ConfirmDialog.vue
+++ b/front/components/dialog/ConfirmDialog.vue
@@ -79,3 +79,9 @@ export default class ConfirmDialog extends Vue {
   }
 }
 </script>
+
+<style scoped>
+.headline {
+  white-space: pre-line;
+}
+</style>

--- a/laravel/app/GraphQL/Mutations/CreateCircleParticipatingInEvent.php
+++ b/laravel/app/GraphQL/Mutations/CreateCircleParticipatingInEvent.php
@@ -15,6 +15,7 @@ class CreateCircleParticipatingInEvent
     public function __invoke($_, array $args)
     {
         $data = Arr::except($args, ['directive']);
+        $data['force'] = $args['force'] ?? false;
         $input = new CreateCircleParticipatingInEventInput($data);
         return (new CreateCircleParticipatingInEventUseCase())->execute($input);
     }

--- a/laravel/app/Models/CirclePlacement.php
+++ b/laravel/app/Models/CirclePlacement.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\{
     BelongsTo,
@@ -60,5 +61,15 @@ class CirclePlacement extends Model
     {
         $eventDate = $this->eventDate;
         return "{$eventDate->name} {$this->hole} {$this->line}-{$this->formatted_number}{$this->a_or_b}";
+    }
+
+    public function findSamePlacements(): Collection
+    {
+        return CirclePlacement::where('event_date_id', $this->event_date_id)
+            ->where('hole', $this->hole)
+            ->where('line', $this->line)
+            ->where('number', $this->number)
+            ->where('a_or_b', $this->a_or_b)
+            ->get();
     }
 }

--- a/laravel/app/UseCase/CareAboutCircle/CreateCareAboutCircle.php
+++ b/laravel/app/UseCase/CareAboutCircle/CreateCareAboutCircle.php
@@ -9,7 +9,20 @@ class CreateCareAboutCircle extends UseCase
 {
     public function execute(CreateCareAboutCircleInput $input)
     {
-        $careAboutCircle = CareAboutCircle::create($input->toArray());
+        $careAboutCircle = $this->findOrCreateCareAboutCircle($input);
         return $careAboutCircle;
+    }
+
+    private function findOrCreateCareAboutCircle(CreateCareAboutCircleInput $input)
+    {
+        $careAboutCircle = CareAboutCircle::where('join_event_id', $input->get('join_event_id'))
+            ->where('circle_placement_id', $input->get('circle_placement_id'))
+            ->first();
+
+        if ($careAboutCircle) {
+            return $careAboutCircle;
+        }
+
+        return CareAboutCircle::create($input->toArray());
     }
 }

--- a/laravel/app/UseCase/ConflictCircleException.php
+++ b/laravel/app/UseCase/ConflictCircleException.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\UseCase;
+
+use Exception;
+
+use Nuwave\Lighthouse\Exceptions\RendersErrorsExtensions;
+use Illuminate\Database\Eloquent\Collection;
+
+class ConflictCircleException extends Exception implements RendersErrorsExtensions
+{
+    private Collection $circles;
+    private Collection $circlePlacements;
+
+    public function __construct(Collection $circles, Collection $circlePlacements, string $message = '')
+    {
+        $circlePlacements->loadMissing('circle');
+        $circles->loadMissing('circlePlacements');
+
+        $this->circles = $circles;
+        $this->circlePlacements = $circlePlacements;
+
+        parent::__construct($message);
+    }
+
+    public function isClientSafe(): bool
+    {
+        return true;
+    }
+
+    public function getCategory(): string
+    {
+        return 'conflictCircle';
+    }
+
+    public function extensionsContent(): array
+    {
+        return [
+            'conflicts' => [
+                'circles' => $this->circles,
+                'circlePlacements' => $this->circlePlacements,
+            ]
+        ];
+    }
+}

--- a/laravel/app/UseCase/ConflictCircleException.php
+++ b/laravel/app/UseCase/ConflictCircleException.php
@@ -9,15 +9,13 @@ use Illuminate\Database\Eloquent\Collection;
 
 class ConflictCircleException extends Exception implements RendersErrorsExtensions
 {
-    private Collection $circles;
     private Collection $circlePlacements;
 
-    public function __construct(Collection $circles, Collection $circlePlacements, string $message = '')
+    public function __construct(Collection $circlePlacements, string $message = '')
     {
         $circlePlacements->loadMissing('circle');
-        $circles->loadMissing('circlePlacements');
+        $circlePlacements->append('formatted_placement');
 
-        $this->circles = $circles;
         $this->circlePlacements = $circlePlacements;
 
         parent::__construct($message);
@@ -36,10 +34,7 @@ class ConflictCircleException extends Exception implements RendersErrorsExtensio
     public function extensionsContent(): array
     {
         return [
-            'conflicts' => [
-                'circles' => $this->circles,
-                'circlePlacements' => $this->circlePlacements,
-            ]
+            'conflicts' =>  $this->circlePlacements,
         ];
     }
 }

--- a/laravel/graphql/circle.graphql
+++ b/laravel/graphql/circle.graphql
@@ -31,7 +31,8 @@ extend type Mutation @guard {
             resolver: "App\\GraphQL\\Mutations\\CreateCircle"
         )
     createCircleParticipatingInEvent(
-        input: CreateCircleParticipatingInEventInput! @spread
+        input: CreateCircleParticipatingInEventInput! @spread,
+        force: Boolean,
     ): CirclePlacement!
         @field(
             resolver: "App\\GraphQL\\Mutations\\CreateCircleParticipatingInEvent"

--- a/laravel/tests/Graphql/CircleTest.php
+++ b/laravel/tests/Graphql/CircleTest.php
@@ -142,8 +142,7 @@ class CircleTest extends TestCase
             ]);
         $error = $response->json('errors.0.extensions');
         $this->assertEquals('conflictCircle', $error['category']);
-        $this->assertEquals($circle->id, $error['conflicts']['circles'][0]['id']);
-        $this->assertCount(0, $error['conflicts']['circlePlacements']);
+        $this->assertEquals($circle->id, $error['conflicts'][0]['circle']['id']);
 
         // 同一配置、別サークルパターン
         $input = $baseInput;
@@ -164,8 +163,7 @@ class CircleTest extends TestCase
             ]);
         $error = $response->json('errors.0.extensions');
         $this->assertEquals('conflictCircle', $error['category']);
-        $this->assertCount(0, $error['conflicts']['circles']);
-        $this->assertEquals($circlePlacement->id, $error['conflicts']['circlePlacements'][0]['id']);
+        $this->assertEquals($circlePlacement->id, $error['conflicts'][0]['id']);
 
         // 同一配置、同一サークルパターン
         // note: この場合はエラーにならずに、登録済みのものが返ってくるのが正常系


### PR DESCRIPTION
resolve: #301 

## この PR で実装される内容
配置、サークル名がかぶって登録された場合の挙動が変更される
 - 同一配置、別サークル名の場合
   - バリデーションに引っ掛かり、確認ダイアログが表示される
 - 同一サークル名、別配置の場合
   - 同上
 - 同一サークル名、同一配置の場合
   - 登録はされずに、既存のレコードが返ってくる

## 確認

-   [x] 別サークル名、別配置の場合今まで通り登録できること
-   [x] 同一配置、別サークル名の場合にダイアログが出ること
-   [x] 同一サークル名、別配置の場合にダイアログが出ること
-   [x] キャンセル選択時に登録されないこと
-   [x] 実行選択時に登録されること
-   [x] 同一配置、同一サークル名で登録した場合、既存のものが取れること
-   [x] 別イベントと干渉しないこと
![011aecf4-f1e5-4380-8d31-a069d579a047](https://user-images.githubusercontent.com/8841932/177760444-c3bcdf1f-26ae-4046-928b-da2d3b3e7596.gif)

## 備考
