### PR TITLE
#319 リスト画面にページングを適用する

### DIFF
--- a/front/components/circle-list/CircleListTable.vue
+++ b/front/components/circle-list/CircleListTable.vue
@@ -2,13 +2,13 @@
   <v-data-table
     :headers="headers"
     :items="filteredCircleLists"
-    height="calc(100vh - 90px)"
+    height="calc(100vh - 160px)"
     :mobile-breakpoint="0"
-    hide-default-footer
-    disable-pagination
     fixed-header
     multi-sort
     :show-select="isEnablePriceSimulation"
+    :footer-props="footerProps"
+    :items-per-page.sync="itemsPerPage"
     @click:row="onRowClicked"
     @dblclick:row="onRowDblClicked"
     @current-items="onUpdateTableCurrentItems"
@@ -19,7 +19,7 @@
         <export-circle-list
           :is-open.sync="isOpenExportCircleList"
           :table-state="tableState"
-          :circle-list-ids="shownTableCircleListItemIds"
+          :circle-list-ids="exportCircleListIds"
         />
         <circle-list-table-setting
           v-model="settings"
@@ -88,41 +88,32 @@
     <template #[`item.memo`]="{ item }">
       <div class="memo">{{ item.memo }}</div>
     </template>
-    <template #[`body.append`]>
-      <tr>
-        <td :colspan="headers.length">
-          合計金額: {{ totalPrice }}円
+    <template #[`footer.prepend`]>
+      合計金額: {{ totalPrice }}円
 
-          <v-tooltip top>
-            <template #activator="{ on, attrs }">
-              <v-btn icon v-bind="attrs" v-on="on" @click="openPriceBreakdown">
-                <v-icon> mdi-text-box-search-outline </v-icon>
-              </v-btn>
-            </template>
-            <span> 内訳をみる </span>
-          </v-tooltip>
-          <v-tooltip top>
-            <template #activator="{ on, attrs }">
-              <v-btn
-                icon
-                v-bind="attrs"
-                v-on="on"
-                @click="togglePriceSimulation"
-              >
-                <v-icon> mdi-text-box-check-outline </v-icon>
-              </v-btn>
-            </template>
-            <span>
-              <template v-if="isEnablePriceSimulation">
-                金額シミュレーションをやめる
-              </template>
-              <template v-else> 金額シミュレーションする </template>
-              <br />
-              チェックがついたもののみ計算対象になります
-            </span>
-          </v-tooltip>
-        </td>
-      </tr>
+      <v-tooltip top>
+        <template #activator="{ on, attrs }">
+          <v-btn icon v-bind="attrs" v-on="on" @click="openPriceBreakdown">
+            <v-icon> mdi-text-box-search-outline </v-icon>
+          </v-btn>
+        </template>
+        <span> 内訳をみる </span>
+      </v-tooltip>
+      <v-tooltip top>
+        <template #activator="{ on, attrs }">
+          <v-btn icon v-bind="attrs" v-on="on" @click="togglePriceSimulation">
+            <v-icon> mdi-text-box-check-outline </v-icon>
+          </v-btn>
+        </template>
+        <span>
+          <template v-if="isEnablePriceSimulation">
+            金額シミュレーションをやめる
+          </template>
+          <template v-else> 金額シミュレーションする </template>
+          <br />
+          チェックがついたもののみ計算対象になります
+        </span>
+      </v-tooltip>
     </template>
   </v-data-table>
 </template>
@@ -200,6 +191,12 @@ export default class CircleListTable extends Vue {
 
   private shownTableCircleListItemIds: string[] = []
 
+  private itemsPerPage: number = 50
+
+  private readonly footerProps: any = {
+    'items-per-page-options': [30, 50, 100, -1],
+  }
+
   private get headers(): DataTableHeader[] {
     return this.tableState.getTableHeaders()
   }
@@ -240,6 +237,12 @@ export default class CircleListTable extends Vue {
 
       return prev + currentPrice
     }, 0)
+  }
+
+  private get exportCircleListIds(): string[] {
+    return this.itemsPerPage === -1
+      ? this.shownTableCircleListItemIds
+      : this.filteredCircleLists.map((item) => item.id)
   }
 
   @Emit()

--- a/front/components/circle-list/table/ExportCircleList.vue
+++ b/front/components/circle-list/table/ExportCircleList.vue
@@ -43,6 +43,14 @@
                   </v-chip-group>
                 </v-col>
               </v-row>
+              <v-row>
+                <v-col cols="12">
+                  <v-subheader>
+                    ※
+                    リスト画面で全件表示中のみ、ソートが適用されたものが出力されます。
+                  </v-subheader>
+                </v-col>
+              </v-row>
             </v-expansion-panel-content>
           </v-expansion-panel>
         </v-expansion-panels>


### PR DESCRIPTION
resolve: #319 

## この PR で実装される内容
 - リスト画面にページングが追加され、動作が軽くなる
 - 行の最後に表示していた金額計算をフッダーに移した
 - 副次的な修正として、Excel出力する際にテーブルに表示中の項目を参照しているため、影響を受けてうまく動作しなくなるため、全件表示中以外はソートをしていないものを出力対象にした

## 確認

-   [x] ページングが機能すること
![f3ee38dc-79b5-47f8-9e1c-e06ae16afb07](https://user-images.githubusercontent.com/8841932/179967369-1dcf3bb1-5aeb-4935-8a5e-9e15ac5eb4e1.gif)


## 備考
