### PR TITLE
#324 競合エラー表示で落ちる場合があるのを修正

### DIFF
--- a/laravel/app/UseCase/ConflictCircleException.php
+++ b/laravel/app/UseCase/ConflictCircleException.php
@@ -16,7 +16,7 @@ class ConflictCircleException extends Exception implements RendersErrorsExtensio
         $circlePlacements->loadMissing('circle');
         $circlePlacements->append('formatted_placement');
 
-        $this->circlePlacements = $circlePlacements;
+        $this->circlePlacements = $circlePlacements->values();
 
         parent::__construct($message);
     }


### PR DESCRIPTION
resolve: #324 

## この PR で実装される内容
競合エラーを表示する際に落ちていた不具合が修正される

## 確認

-   [x] 該当ケースで問題なくエラー表示できること
![image](https://user-images.githubusercontent.com/8841932/180418761-f1854f71-c65c-43cc-94e2-b9e4ac1c1de0.png)


## 備考
