### PR TITLE
#337 サークル配置登録更新時に半角全角の統一を行う

### DIFF
--- a/laravel/app/Observers/CirclePlacementObserver.php
+++ b/laravel/app/Observers/CirclePlacementObserver.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Observers;
+
+use App\Models\CirclePlacement;
+
+class CirclePlacementObserver
+{
+    public function saving(CirclePlacement $circlePlacement)
+    {
+        $circlePlacement->line = mb_convert_kana($circlePlacement->line, 'aKV');
+    }
+}

--- a/laravel/app/Providers/EventServiceProvider.php
+++ b/laravel/app/Providers/EventServiceProvider.php
@@ -6,8 +6,10 @@ use Illuminate\Auth\Events\Registered;
 use Illuminate\Auth\Listeners\SendEmailVerificationNotification;
 use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvider;
 
+use App\Models\CirclePlacement;
 use App\Models\EventDate;
 use App\Models\Team;
+use App\Observers\CirclePlacementObserver;
 use App\Observers\EventDateObserver;
 use App\Observers\TeamObserver;
 
@@ -31,6 +33,7 @@ class EventServiceProvider extends ServiceProvider
      */
     public function boot()
     {
+        CirclePlacement::observe(CirclePlacementObserver::class);
         Team::observe(TeamObserver::class);
         EventDate::observe(EventDateObserver::class);
     }

--- a/laravel/tests/Feature/Models/CirclePlacementTest.php
+++ b/laravel/tests/Feature/Models/CirclePlacementTest.php
@@ -36,4 +36,59 @@ class CirclePlacementTest extends TestCase
             $this->assertEquals($circlePlacement->id, $foundCirclePlacement->id);
         });
     }
+
+    /**
+     * @dataProvider savingObserverProvider
+     */
+    public function testSavingObserver($expectedLine, $circlePlacementsAttributes)
+    {
+        collect($circlePlacementsAttributes)
+            ->map(fn ($attributes) => CirclePlacement::factory($attributes)->create())
+            ->each(function ($circlePlacement) use ($expectedLine) {
+                $this->assertEquals($expectedLine, $circlePlacement->line);
+                $this->assertDatabaseHas('circle_placements', [
+                    'id' => $circlePlacement->id,
+                    'line' => $expectedLine,
+                ]);
+            });
+    }
+
+    public function savingObserverProvider()
+    {
+        return [
+            'full width alphabet to half width' => [
+                'A',
+                [
+                    [
+                        'line' => 'Ａ',
+                    ],
+                    [
+                        'line' => 'A',
+                    ],
+                ],
+            ],
+            'half width katakana to full width' => [
+                'ア',
+                [
+                    [
+                        'line' => 'ア',
+                    ],
+                    [
+                        'line' => 'ｱ',
+                    ],
+                ]
+            ],
+            'full width number to half width' => [
+                '1',
+                [
+                    [
+                        'line' => '１',
+                    ],
+                    [
+                        'line' => '1',
+                    ]
+                ],
+            ],
+        ];
+    }
 }


### PR DESCRIPTION
resolve: #337 

## この PR で実装される内容
サークル配置登録編集時に以下のように統一される
・半角カタカナ　→　全角カタカナ
・全角英数　→　半角英数

## 確認

-   [x] 変換がされること
![a4a6c0fa-f5a0-4dac-899a-da72f82376c0](https://user-images.githubusercontent.com/8841932/183278699-23da8ed3-ae48-45b6-b473-83ae53cb1f55.gif)

## 備考
