### PR TITLE
#339 リスト上でお気に入りボタンの誤爆解除対策に確認ダイアログと、ボタンの無効化の設定を追加

### DIFF
--- a/front/components/circle-list/CircleListTable.vue
+++ b/front/components/circle-list/CircleListTable.vue
@@ -72,7 +72,10 @@
       </v-expand-transition>
     </template>
     <template #[`item.circle_name`]="{ item }">
-      <favorite-button :circle-id="item.circle_id" />
+      <favorite-button
+        :circle-id="item.circle_id"
+        :disabled="!settings.isEnableFavoriteButton"
+      />
       {{ item.circle_name }}
     </template>
     <template #[`item.circle_product_price`]="{ item }">
@@ -185,6 +188,7 @@ export default class CircleListTable extends Vue {
   //       ちょっと複雑な動作をしているため、シンプルな実装にできるのであれば、変更も考えたい
   private settings: CircleListTableSettings = {
     howOpenCircleListForm: 'click',
+    isEnableFavoriteButton: true,
   }
 
   private filterConditions: FilterConditions = {}

--- a/front/components/circle-list/FavoriteCircleListTable.vue
+++ b/front/components/circle-list/FavoriteCircleListTable.vue
@@ -70,6 +70,7 @@ export default class CircleListTable extends Vue {
   //       ちょっと複雑な動作をしているため、シンプルな実装にできるのであれば、変更も考えたい
   private settings: CircleListTableSettings = {
     howOpenCircleListForm: 'click',
+    isEnableFavoriteButton: true,
   }
 
   private readonly headers: DataTableHeader[] = [

--- a/front/components/circle-list/table/CircleListTableSetting.vue
+++ b/front/components/circle-list/table/CircleListTableSetting.vue
@@ -17,6 +17,19 @@
             />
           </v-col>
         </v-row>
+        <v-row>
+          <v-col cols="12">
+            <v-select
+              v-model="settings.isEnableFavoriteButton"
+              :items="isEnableFavoriteButtonOptions"
+              item-text="text"
+              item-value="value"
+              label="リスト上のお気に入りボタンのクリック"
+              :persistent-hint="true"
+              hint="お気に入りボタンクリックの誤爆が気になる場合、無効にするとボタンの表示のみになり、クリックに反応しなくなります。"
+            />
+          </v-col>
+        </v-row>
       </v-card-text>
     </v-card>
   </v-dialog>
@@ -31,8 +44,13 @@ type HowOpenCircleListOption = {
   value: HowOpenCircleListValue
   text: string
 }
+type IsEnableFavoriteButtonOption = {
+  value: boolean
+  text: string
+}
 export type CircleListTableSettings = {
   howOpenCircleListForm: HowOpenCircleListValue
+  isEnableFavoriteButton: boolean
 }
 
 @Component({})
@@ -71,6 +89,17 @@ export default class CircleListTableSetting extends Vue {
     {
       value: 'dblclick',
       text: 'ダブルクリック',
+    },
+  ]
+
+  private isEnableFavoriteButtonOptions: IsEnableFavoriteButtonOption[] = [
+    {
+      value: false,
+      text: '無効',
+    },
+    {
+      value: true,
+      text: '有効',
     },
   ]
 

--- a/front/components/favorites/FavoriteButton.vue
+++ b/front/components/favorites/FavoriteButton.vue
@@ -83,7 +83,17 @@ export default class FavoriteButton extends Vue {
       })
   }
 
-  private deleteFavorite(): Promise<any> {
+  private async deleteFavorite(): Promise<any> {
+    const circleName = this.favorite?.circle?.name
+    const messagePrefix = circleName ? `${circleName}の` : ''
+    if (
+      !(await this.$confirmDialog.confirm(
+        `${messagePrefix}お気に入りを解除します。よろしいですか？`
+      ))
+    ) {
+      return false
+    }
+
     const variables = {
       id: this.favorite!.id,
     }


### PR DESCRIPTION
resolve: #339

## この PR で実装される内容
リスト画面テーブルでのお気に入りボタンのdisabledが設定できるようになる
お気に入り解除時に確認ダイアログが出るようになる

## 確認

-   [x] disabledを付与できること
-   [x] 確認ダイアログが表示されること
![e031efd1-48d7-4b27-953c-f4b796047aa9](https://user-images.githubusercontent.com/8841932/183279408-a8d2b300-7071-49c8-9ba6-fecd5ae54737.gif)


## 備考
