### PR TITLE
#352 fix: 東7ホールの選択肢追加

### DIFF
--- a/front/components/circle-list/form/circle-form/CirclePlacementFormInput.vue
+++ b/front/components/circle-list/form/circle-form/CirclePlacementFormInput.vue
@@ -114,6 +114,7 @@ export default class CirclePlacementFormInput extends AbstractFormInput<
   // TODO: イベントごとにホールのマスタを変更できるようにする？
   private holes: { name: string }[] = [
     { name: '東' },
+    { name: '東7' },
     { name: '西' },
     { name: '南' },
   ]


### PR DESCRIPTION
resolve: #352 

## この PR で実装される内容
東7ホールの選択肢が追加される

## 悩ましい（見てほしい）部分

## 確認

- [x] a, Aをソートできる
- [x] 競合は反応する（東と東7は競合しない）

## 備考
