### PR TITLE
#357　配置日が1つのみの場合、自動入力されるようにする

### DIFF
--- a/docs/テストデータ.md
+++ b/docs/テストデータ.md
@@ -1,0 +1,25 @@
+## テストデータ
+特定のSeederでテスト用の投入データを定義しているため、コマンドを実施することで初期データの投入ができる
+
+## 投入方法
+下記コマンドを実行
+
+```bash
+docker-compose exec laravel bash
+php artisan db:seed --class=Database\\Seeders\\BasicDatasetSeeder
+```
+
+### ログインユーザ
+投入されたテストデータのユーザは下記でログイン可能  
+  
+email: `test@test.test`  
+pass: `password`  
+  
+複数回ユーザのテストデータを生成した場合は、emailにindexが付く
+ex) `test2@test.test`
+
+## メンテナンス
+`Database\DatasetFactories\*` にてテスト用データの生成を行っている。  
+実装でDB定義が更新された場合などは、対応するファイル内でテスト用データの定義を行うこと  
+  
+※ ここで定義したデータはSeeder、バックエンドの自動テストの双方に反映される

--- a/docs/環境構築.md
+++ b/docs/環境構築.md
@@ -46,6 +46,7 @@ php artisan key:generate
 
 ```sh
 php artisan migrate --seed
+php artisan db:seed --class=Database\\Seeders\\BasicDatasetSeeder
 ```
 
 #### (optional)IDE用の補助ファイル生成

--- a/front/components/circle-list/form/circle-form/CirclePlacementFormInput.vue
+++ b/front/components/circle-list/form/circle-form/CirclePlacementFormInput.vue
@@ -61,7 +61,7 @@
 </template>
 
 <script lang="ts">
-import { Prop, Component } from 'nuxt-property-decorator'
+import { Prop, Component, Watch } from 'nuxt-property-decorator'
 import AbstractFormInput from '~/components/form/AbstractFormInput.vue'
 import {
   CirclePlacementInput,
@@ -122,5 +122,12 @@ export default class CirclePlacementFormInput extends AbstractFormInput<
   private aOrB: { name: string }[] = [{ name: 'a' }, { name: 'b' }]
 
   private circlePlacementClassifications: CirclePlacementClassification[] = []
+
+  @Watch('eventDates', { immediate: true })
+  private onUpdateEventDates() {
+    if (this.eventDates && this.eventDates.length === 1) {
+      this.input.event_date_id = this.eventDates[0].id
+    }
+  }
 }
 </script>


### PR DESCRIPTION
resolve: #357

## この PR で実装される内容
- 配置日が1つのみの場合、自動入力されるようになる

## 悩ましい（見てほしい）部分

## 確認

-   [x] 日付が単一の場合、自動選択される
-   [x] 日付が複数の場合、自動選択されない

## 備考
