### PR TITLE
#361 feat: サークル配置入力時に、配置日に日付・曜日を付与する

### DIFF
--- a/front/apollo/queries/eventWithDate.gql
+++ b/front/apollo/queries/eventWithDate.gql
@@ -6,6 +6,7 @@ query EventWithDateQuery($id: ID!) {
       id
       name
       date
+      full_format_date
     }
   }
 }

--- a/front/components/circle-list/form/circle-form/CirclePlacementFormInput.vue
+++ b/front/components/circle-list/form/circle-form/CirclePlacementFormInput.vue
@@ -5,7 +5,7 @@
         <v-validate-select
           v-model="input.event_date_id"
           :items="eventDates"
-          item-text="name"
+          item-text="full_format_date"
           item-value="id"
           :validation="validation.getItem('placement.event_date_id')"
         />

--- a/front/test/factory/EventDateFactory.ts
+++ b/front/test/factory/EventDateFactory.ts
@@ -4,12 +4,16 @@ import Factory from './Factory'
 
 export default class EventDateFactory extends Factory<EventDate> {
   protected provide(): EventDate {
+    const name = this.faker.name.title()
+    const date = moment(this.faker.date.between('2000-01-01', '2020-01-01')).format(
+      'Y-m-d'
+    )
+
     return {
       id: this.faker.datatype.uuid(),
-      name: this.faker.name.title(),
-      date: moment(this.faker.date.between('2000-01-01', '2020-01-01')).format(
-        'Y-m-d'
-      ),
+      name,
+      date,
+      full_format_date: `${name}（${date}）`,
       is_production_day: this.faker.datatype.boolean(),
     }
   }

--- a/laravel/app/Models/EventDate.php
+++ b/laravel/app/Models/EventDate.php
@@ -17,4 +17,11 @@ class EventDate extends Model
     {
         return $this->belongsTo(Event::class);
     }
+
+    public function getFullFormatDateAttribute(): string
+    {
+        $day = $this->date->getTranslatedDayName();
+        $dateString = $this->date->format('Y/m/d');
+        return "{$this->name}（{$dateString} {$day}）";
+    }
 }

--- a/laravel/graphql/eventDate.graphql
+++ b/laravel/graphql/eventDate.graphql
@@ -3,6 +3,7 @@ type EventDate {
     event: Event @belongsTo
     name: String!
     date: Date!
+    full_format_date: String!
     is_production_day: Boolean!
     created_at: DateTime
     updated_at: DateTime

--- a/laravel/tests/Feature/Models/EventDateTest.php
+++ b/laravel/tests/Feature/Models/EventDateTest.php
@@ -6,6 +6,7 @@ use Illuminate\Foundation\Testing\WithFaker;
 
 use App\Models\Event;
 use App\Models\EventDate;
+use Str;
 use Tests\TestCase;
 
 class EventDateTest extends TestCase
@@ -34,5 +35,11 @@ class EventDateTest extends TestCase
         ]);
         $event->refresh();
         $this->assertTrue($event->is_progress);
+    }
+
+    public function testAttributes()
+    {
+        $eventDate = EventDate::factory()->create();
+        $this->assertTrue(Str::startsWith($eventDate->full_format_date, $eventDate->name));
     }
 }


### PR DESCRIPTION
resolve: #361 

## この PR で実装される内容
- サークル配置入力の際に、配置日に日付・曜日が付与されるようになる
  - `1日目（2024/12/30　月曜日）`

## 悩ましい（見てほしい）部分

## 確認

-   [x] 配置日の表示が更新される

## 備考
